### PR TITLE
Update examples to mbed-os 5.3.0

### DIFF
--- a/authcrypt/mbed-os.lib
+++ b/authcrypt/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#503262c91bc51619ec540490d3e4a058e0c8ebf1
+https://github.com/ARMmbed/mbed-os/#7b974cac6578f4761a60ac140bad807eb946c110

--- a/authcrypt/mbed-os.lib
+++ b/authcrypt/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#fc1f4391614a88f10f800fd2644e74ed94530f1c
+https://github.com/ARMmbed/mbed-os/#503262c91bc51619ec540490d3e4a058e0c8ebf1

--- a/authcrypt/mbed-os.lib
+++ b/authcrypt/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e2617cc0e17f5c3fc2bae6a589c9bcfd3d1a717b
+https://github.com/ARMmbed/mbed-os/#fc1f4391614a88f10f800fd2644e74ed94530f1c

--- a/authcrypt/mbed-os.lib
+++ b/authcrypt/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#7b974cac6578f4761a60ac140bad807eb946c110
+https://github.com/ARMmbed/mbed-os/#532da7133f7d51db958eacb2b5f13e7cf7feb81f

--- a/benchmark/mbed-os.lib
+++ b/benchmark/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#503262c91bc51619ec540490d3e4a058e0c8ebf1
+https://github.com/ARMmbed/mbed-os/#7b974cac6578f4761a60ac140bad807eb946c110

--- a/benchmark/mbed-os.lib
+++ b/benchmark/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#fc1f4391614a88f10f800fd2644e74ed94530f1c
+https://github.com/ARMmbed/mbed-os/#503262c91bc51619ec540490d3e4a058e0c8ebf1

--- a/benchmark/mbed-os.lib
+++ b/benchmark/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e2617cc0e17f5c3fc2bae6a589c9bcfd3d1a717b
+https://github.com/ARMmbed/mbed-os/#fc1f4391614a88f10f800fd2644e74ed94530f1c

--- a/benchmark/mbed-os.lib
+++ b/benchmark/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#7b974cac6578f4761a60ac140bad807eb946c110
+https://github.com/ARMmbed/mbed-os/#532da7133f7d51db958eacb2b5f13e7cf7feb81f

--- a/hashing/mbed-os.lib
+++ b/hashing/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#503262c91bc51619ec540490d3e4a058e0c8ebf1
+https://github.com/ARMmbed/mbed-os/#7b974cac6578f4761a60ac140bad807eb946c110

--- a/hashing/mbed-os.lib
+++ b/hashing/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#fc1f4391614a88f10f800fd2644e74ed94530f1c
+https://github.com/ARMmbed/mbed-os/#503262c91bc51619ec540490d3e4a058e0c8ebf1

--- a/hashing/mbed-os.lib
+++ b/hashing/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e2617cc0e17f5c3fc2bae6a589c9bcfd3d1a717b
+https://github.com/ARMmbed/mbed-os/#fc1f4391614a88f10f800fd2644e74ed94530f1c

--- a/hashing/mbed-os.lib
+++ b/hashing/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#7b974cac6578f4761a60ac140bad807eb946c110
+https://github.com/ARMmbed/mbed-os/#532da7133f7d51db958eacb2b5f13e7cf7feb81f

--- a/tls-client/mbed-os.lib
+++ b/tls-client/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#503262c91bc51619ec540490d3e4a058e0c8ebf1
+https://github.com/ARMmbed/mbed-os/#7b974cac6578f4761a60ac140bad807eb946c110

--- a/tls-client/mbed-os.lib
+++ b/tls-client/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#fc1f4391614a88f10f800fd2644e74ed94530f1c
+https://github.com/ARMmbed/mbed-os/#503262c91bc51619ec540490d3e4a058e0c8ebf1

--- a/tls-client/mbed-os.lib
+++ b/tls-client/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e2617cc0e17f5c3fc2bae6a589c9bcfd3d1a717b
+https://github.com/ARMmbed/mbed-os/#fc1f4391614a88f10f800fd2644e74ed94530f1c

--- a/tls-client/mbed-os.lib
+++ b/tls-client/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#7b974cac6578f4761a60ac140bad807eb946c110
+https://github.com/ARMmbed/mbed-os/#532da7133f7d51db958eacb2b5f13e7cf7feb81f


### PR DESCRIPTION
This PR updates the `mbed-os.lib` files for each of the examples to mbed OS commit [532da7133f7d51db958eacb2b5f13e7cf7feb81f](https://github.com/ARMmbed/mbed-os/commit/532da7133f7d51db958eacb2b5f13e7cf7feb81f), corresponding to the git tag `mbed-os-5.3.0`.