### PR TITLE
Conditionally def MBEDTLS_SHA1_C to avoid redef

### DIFF
--- a/tls-client/mbedtls_entropy_config.h
+++ b/tls-client/mbedtls_entropy_config.h
@@ -23,7 +23,9 @@
 #endif /* !MBEDTLS_ENTROPY_HARDWARE_ALT && !MBEDTLS_ENTROPY_NV_SEED &&
         * !MBEDTLS_TEST_NULL_ENTROPY */
 
+#if !defined(MBEDTLS_SHA1_C)
 #define MBEDTLS_SHA1_C
+#endif /* !MBEDTLS_SHA1_C */
 
 /*
  *  This value is sufficient for handling 2048 bit RSA keys.


### PR DESCRIPTION
The tls-client example requires SHA1 because it is needed to be ale to verify certificates. However, this feature is disabled by default in mbed OS, so the user-defined config.h defines the macro MBEDTLS_SHA1_C to enable it. However, some platforms have drivers that also define MBEDTLS_SHA1_C, which might result in several macro redefinition warning during compilation. This patch solves the problem by defining MBEDTLS_SHA1_C in the tls-client user-config only if it is not already defined.