### PR TITLE
Disable EMAC feature in ublox to fix tls-client

### DIFF
--- a/tls-client/mbed_app.json
+++ b/tls-client/mbed_app.json
@@ -1,5 +1,10 @@
 {
     "macros": [
         "MBEDTLS_USER_CONFIG_FILE=\"mbedtls_entropy_config.h\""
-    ]
+    ],
+    "target_overrides": {
+        "UBLOX_EVK_ODIN_W2": {
+            "target.device_has_remove": ["EMAC"]
+        }
+    }
 }


### PR DESCRIPTION
When the macro DEVICE_EMAC is enabled, the program will try to use Wifi
by default. However, the tls-client example only supports Ethernet, so
it fails. To avoid this we use the device_has_remove field in the
mbed_app.json to disable the EMAC feature for UBLOX_EVK_ODIN_W2.