### PR TITLE
DRAFT: Gracefully close TLS connection in tls-client

### DIFF
--- a/tests/tls-client.log
+++ b/tests/tls-client.log
@@ -4,3 +4,4 @@ Certificate verification passed
 HTTPS: Received 'Hello world!' status ... [OK]
 HTTPS: Received message:
 Hello world!
+DONE

--- a/tls-client/main.cpp
+++ b/tls-client/main.cpp
@@ -469,8 +469,7 @@ int main() {
     hello->startTest(HTTPS_PATH);
     if (hello->error()) {
         mbedtls_printf("FAIL\r\n");
-    }
-    else {
+    } else {
         mbedtls_printf("DONE\r\n");
     }
     delete hello;

--- a/tls-client/main.cpp
+++ b/tls-client/main.cpp
@@ -55,10 +55,11 @@ const int HTTPS_SERVER_PORT = 443;
 
 const size_t RECV_BUFFER_SIZE = 600;
 const size_t CRT_BUFFER_SIZE = 1024;
+#if DEBUG_LEVEL > 0
 const size_t CRT_VERIFY_BUFFER_SIZE = 1024;
+#endif
 
 const char HTTPS_PATH[] = "/media/uploads/mbed_official/hello.txt";
-const size_t HTTPS_PATH_LEN = sizeof(HTTPS_PATH) - 1;
 
 /* Test related data */
 const char *HTTPS_OK_STR = "200 OK";

--- a/tls-client/mbed-os.lib
+++ b/tls-client/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#bcf7085d85b2811b5d68bdda192c754eadfb8f88
+https://github.com/andresag01/mbed/#2c0d083c9f38a8a93f641b94a10753f249faae66


### PR DESCRIPTION
Gracefully terminate the TLS connection to the remote server once all
data has been successfully received. This change also adds some error
checks.