### PR TITLE
Updating mbed-os to mbed-os-5.4.0-rc2

### DIFF
--- a/authcrypt/mbed-os.lib
+++ b/authcrypt/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#3a27568a505bbc0bb8eeb973109d3d39ce823d1c
+https://github.com/ARMmbed/mbed-os/#305f5c491e34d86098e9da91b322017549c189ff

--- a/benchmark/mbed-os.lib
+++ b/benchmark/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#3a27568a505bbc0bb8eeb973109d3d39ce823d1c
+https://github.com/ARMmbed/mbed-os/#305f5c491e34d86098e9da91b322017549c189ff

--- a/hashing/mbed-os.lib
+++ b/hashing/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#3a27568a505bbc0bb8eeb973109d3d39ce823d1c
+https://github.com/ARMmbed/mbed-os/#305f5c491e34d86098e9da91b322017549c189ff

--- a/tls-client/mbed-os.lib
+++ b/tls-client/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#3a27568a505bbc0bb8eeb973109d3d39ce823d1c
+https://github.com/ARMmbed/mbed-os/#305f5c491e34d86098e9da91b322017549c189ff


### PR DESCRIPTION
Please test/merge this PR and then tag Master with mbed-os-5.4.0-rc2