### PR TITLE
Typo in Throughput log

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -13,21 +13,21 @@ You can also compile this example with the [mbed Online Compiler](https://develo
 The output in the terminal window should be similar to this:
 
 ```
-  SHA-256                  :       1673 Kb/s,         70 cycles/byte
-  SHA-512                  :        546 Kb/s,        215 cycles/byte
-  AES-CBC-128              :       1428 Kb/s,         82 cycles/byte
-  AES-CBC-192              :       1260 Kb/s,         93 cycles/byte
-  AES-CBC-256              :       1127 Kb/s,        104 cycles/byte
-  AES-GCM-128              :        486 Kb/s,        242 cycles/byte
-  AES-GCM-192              :        464 Kb/s,        253 cycles/byte
-  AES-GCM-256              :        445 Kb/s,        264 cycles/byte
-  AES-CCM-128              :        610 Kb/s,        192 cycles/byte
-  AES-CCM-192              :        547 Kb/s,        214 cycles/byte
-  AES-CCM-256              :        496 Kb/s,        237 cycles/byte
-  CTR_DRBG (NOPR)          :       1139 Kb/s,        102 cycles/byte
-  CTR_DRBG (PR)            :        826 Kb/s,        142 cycles/byte
-  HMAC_DRBG SHA-256 (NOPR) :        193 Kb/s,        611 cycles/byte
-  HMAC_DRBG SHA-256 (PR)   :        170 Kb/s,        695 cycles/byte
+  SHA-256                  :       1673 KB/s,         70 cycles/byte
+  SHA-512                  :        546 KB/s,        215 cycles/byte
+  AES-CBC-128              :       1428 KB/s,         82 cycles/byte
+  AES-CBC-192              :       1260 KB/s,         93 cycles/byte
+  AES-CBC-256              :       1127 KB/s,        104 cycles/byte
+  AES-GCM-128              :        486 KB/s,        242 cycles/byte
+  AES-GCM-192              :        464 KB/s,        253 cycles/byte
+  AES-GCM-256              :        445 KB/s,        264 cycles/byte
+  AES-CCM-128              :        610 KB/s,        192 cycles/byte
+  AES-CCM-192              :        547 KB/s,        214 cycles/byte
+  AES-CCM-256              :        496 KB/s,        237 cycles/byte
+  CTR_DRBG (NOPR)          :       1139 KB/s,        102 cycles/byte
+  CTR_DRBG (PR)            :        826 KB/s,        142 cycles/byte
+  HMAC_DRBG SHA-256 (NOPR) :        193 KB/s,        611 cycles/byte
+  HMAC_DRBG SHA-256 (PR)   :        170 KB/s,        695 cycles/byte
   RSA-2048                 :      28 ms/ public
   RSA-2048                 :     953 ms/private
   RSA-4096                 :      93 ms/ public

--- a/benchmark/main.cpp
+++ b/benchmark/main.cpp
@@ -213,7 +213,7 @@ do {                                                                           \
         CODE;                                                                  \
     }                                                                          \
                                                                                \
-    mbedtls_printf( "%9lu Kb/s,  %9lu cycles/byte\r\n",                        \
+    mbedtls_printf( "%9lu KB/s,  %9lu cycles/byte\r\n",                        \
                      i * BUFSIZE / 1024,                                       \
                      ( mbedtls_timing_hardclock() - tsc ) / ( j * BUFSIZE ) ); \
 } while( 0 )

--- a/tests/benchmark.log
+++ b/tests/benchmark.log
@@ -1,18 +1,18 @@
-  SHA-256                  :\s*\d+ Kb/s,\s*\d+ cycles/byte
-  SHA-512                  :\s*\d+ Kb/s,\s*\d+ cycles/byte
-  AES-CBC-128              :\s*\d+ Kb/s,\s*\d+ cycles/byte
-  AES-CBC-192              :\s*\d+ Kb/s,\s*\d+ cycles/byte
-  AES-CBC-256              :\s*\d+ Kb/s,\s*\d+ cycles/byte
-  AES-GCM-128              :\s*\d+ Kb/s,\s*\d+ cycles/byte
-  AES-GCM-192              :\s*\d+ Kb/s,\s*\d+ cycles/byte
-  AES-GCM-256              :\s*\d+ Kb/s,\s*\d+ cycles/byte
-  AES-CCM-128              :\s*\d+ Kb/s,\s*\d+ cycles/byte
-  AES-CCM-192              :\s*\d+ Kb/s,\s*\d+ cycles/byte
-  AES-CCM-256              :\s*\d+ Kb/s,\s*\d+ cycles/byte
-  CTR_DRBG \(NOPR\)          :\s*\d+ Kb/s,\s*\d+ cycles/byte
-  CTR_DRBG \(PR\)            :\s*\d+ Kb/s,\s*\d+ cycles/byte
-  HMAC_DRBG SHA-256 \(NOPR\) :\s*\d+ Kb/s,\s*\d+ cycles/byte
-  HMAC_DRBG SHA-256 \(PR\)   :\s*\d+ Kb/s,\s*\d+ cycles/byte
+  SHA-256                  :\s*\d+ KB/s,\s*\d+ cycles/byte
+  SHA-512                  :\s*\d+ KB/s,\s*\d+ cycles/byte
+  AES-CBC-128              :\s*\d+ KB/s,\s*\d+ cycles/byte
+  AES-CBC-192              :\s*\d+ KB/s,\s*\d+ cycles/byte
+  AES-CBC-256              :\s*\d+ KB/s,\s*\d+ cycles/byte
+  AES-GCM-128              :\s*\d+ KB/s,\s*\d+ cycles/byte
+  AES-GCM-192              :\s*\d+ KB/s,\s*\d+ cycles/byte
+  AES-GCM-256              :\s*\d+ KB/s,\s*\d+ cycles/byte
+  AES-CCM-128              :\s*\d+ KB/s,\s*\d+ cycles/byte
+  AES-CCM-192              :\s*\d+ KB/s,\s*\d+ cycles/byte
+  AES-CCM-256              :\s*\d+ KB/s,\s*\d+ cycles/byte
+  CTR_DRBG \(NOPR\)          :\s*\d+ KB/s,\s*\d+ cycles/byte
+  CTR_DRBG \(PR\)            :\s*\d+ KB/s,\s*\d+ cycles/byte
+  HMAC_DRBG SHA-256 \(NOPR\) :\s*\d+ KB/s,\s*\d+ cycles/byte
+  HMAC_DRBG SHA-256 \(PR\)   :\s*\d+ KB/s,\s*\d+ cycles/byte
   RSA-2048                 :\s*\d+ ms/ public
   RSA-2048                 :\s*\d+ ms/private
   RSA-4096                 :\s*\d+ ms/ public


### PR DESCRIPTION
Throughput is printed in Kb instead of KB
Fixed issue #69