### PR TITLE
mbed-os.lib: fix sha for the workshop

### DIFF
--- a/authcrypt/mbed-os.lib
+++ b/authcrypt/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#6743d926f3a794f8413cddb859786890abf0db2c
+https://github.com/ARMmbed/mbed-os/#567dbf7c51374e4d869e1348e509b7c7319dfa01

--- a/benchmark/mbed-os.lib
+++ b/benchmark/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#6743d926f3a794f8413cddb859786890abf0db2c
+https://github.com/ARMmbed/mbed-os/#567dbf7c51374e4d869e1348e509b7c7319dfa01

--- a/hashing/mbed-os.lib
+++ b/hashing/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#6743d926f3a794f8413cddb859786890abf0db2c
+https://github.com/ARMmbed/mbed-os/#567dbf7c51374e4d869e1348e509b7c7319dfa01

--- a/tls-client/mbed-os.lib
+++ b/tls-client/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#6743d926f3a794f8413cddb859786890abf0db2c
+https://github.com/ARMmbed/mbed-os/#567dbf7c51374e4d869e1348e509b7c7319dfa01


### PR DESCRIPTION
The previous SHA does not  exist in the tree anymore (branch was deleted) ,this should be the correct one. Please review