### PR TITLE
TLS-Client - use easy-connect

### DIFF
--- a/tls-client/.mbedignore
+++ b/tls-client/.mbedignore
@@ -1,0 +1,7 @@
+easy-connect/atmel-rf-driver/*
+easy-connect/mcr20a-rf-driver/*
+easy-connect/esp8266-driver/*
+easy-connect/stm-spirit1-rf-driver/*
+easy-connect/wifi-x-nucleo-idw01m1/*
+
+

--- a/tls-client/README.md
+++ b/tls-client/README.md
@@ -11,6 +11,7 @@ You can also compile this example with the [mbed Online Compiler](https://os.mbe
 ## Required hardware
 
 This example also requires an Ethernet cable and connection to the internet additional to the hardware requirements in the [main readme](../README.md).
+Please read different networking setups instructions from [Easy Connect](https://github.com/ARMmbed/easy-connect/blob/master/README.md).
 
 The networking stack used in this example requires TLS functionality to be enabled on mbed TLS. On devices where hardware entropy is not present, TLS is disabled by default. This would result in compile time or linking failures.
 
@@ -18,13 +19,17 @@ To learn why entropy is required, read the [TLS Porting guide](https://docs.mbed
 
 ## Monitoring the application
 
-__NOTE:__ Make sure that the Ethernet cable is plugged in correctly before running the application.
+__NOTE:__ Make sure that the network is functional before running the application.
 
 The output in the terminal window should be similar to this:
 
 ```
 Using Ethernet LWIP
-Client IP Address is 172.16.8.12
+Client IP Address is 10.2.203.43
+Connecting with developer.mbed.org
+[EasyConnect] Connected to Network successfully
+[EasyConnect] MAC address ae:41:46:27:31:e7
+[EasyConnect] IP address 192.168.64.255
 Connecting with os.mbed.com
 Starting the TLS handshake...
 TLS connection to os.mbed.com established

--- a/tls-client/README.md
+++ b/tls-client/README.md
@@ -24,9 +24,6 @@ __NOTE:__ Make sure that the network is functional before running the applicatio
 The output in the terminal window should be similar to this:
 
 ```
-Using Ethernet LWIP
-Client IP Address is 10.2.203.43
-Connecting with developer.mbed.org
 [EasyConnect] Connected to Network successfully
 [EasyConnect] MAC address ae:41:46:27:31:e7
 [EasyConnect] IP address 192.168.64.255

--- a/tls-client/README.md
+++ b/tls-client/README.md
@@ -24,6 +24,8 @@ __NOTE:__ Make sure that the network is functional before running the applicatio
 The output in the terminal window should be similar to this:
 
 ```
+Starting mbed-os-example-tls/tls-client
+Using Mbed OS 5.X.Y
 [EasyConnect] Connected to Network successfully
 [EasyConnect] MAC address ae:41:46:27:31:e7
 [EasyConnect] IP address 192.168.64.255

--- a/tls-client/easy-connect.lib
+++ b/tls-client/easy-connect.lib
@@ -1,0 +1,1 @@
+https://github.com/ARMmbed/easy-connect/#e6b7ee2f932bdc5718ac7ddbd2658c2e1f0b4fd3

--- a/tls-client/easy-connect.lib
+++ b/tls-client/easy-connect.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/easy-connect/#e6b7ee2f932bdc5718ac7ddbd2658c2e1f0b4fd3
+https://github.com/ARMmbed/easy-connect/#e44b96188010dc8d453721ba913f9ac9d9c3d6c5

--- a/tls-client/main.cpp
+++ b/tls-client/main.cpp
@@ -33,6 +33,7 @@
 #define DEBUG_LEVEL 0
 
 #include "mbed.h"
+#include "easy-connect.h"
 #include "NetworkStack.h"
 
 #include "EthernetInterface.h"
@@ -418,18 +419,15 @@ int main() {
     /* The default 9600 bps is too slow to print full TLS debug info and could
      * cause the other party to time out. */
 
-    /* Inititalise with DHCP, connect, and start up the stack */
-    EthernetInterface eth_iface;
-    eth_iface.connect();
-    mbedtls_printf("Using Ethernet LWIP\r\n");
-    const char *ip_addr = eth_iface.get_ip_address();
-    if (ip_addr) {
-        mbedtls_printf("Client IP Address is %s\r\n", ip_addr);
-    } else {
-        mbedtls_printf("No Client IP Address\r\n");
+    /* Use the easy-connect lib to support multiple network bearers.   */
+    /* See https://github.com/ARMmbed/easy-connect README.md for info. */
+    NetworkInterface* network = easy_connect(true); /* has 1 argument, enable_logging (pass in true to log to serial port) */
+    if (!network) {
+        printf("Connecting to the network failed... See serial output.\r\n");
+        return 1;
     }
 
-    HelloHTTPS *hello = new HelloHTTPS(HTTPS_SERVER_NAME, HTTPS_SERVER_PORT, &eth_iface);
+    HelloHTTPS *hello = new HelloHTTPS(HTTPS_SERVER_NAME, HTTPS_SERVER_PORT, network);
     hello->startTest(HTTPS_PATH);
     delete hello;
 }

--- a/tls-client/main.cpp
+++ b/tls-client/main.cpp
@@ -34,10 +34,6 @@
 
 #include "mbed.h"
 #include "easy-connect.h"
-#include "NetworkStack.h"
-
-#include "EthernetInterface.h"
-#include "TCPSocket.h"
 
 #include "mbedtls/platform.h"
 #include "mbedtls/ssl.h"

--- a/tls-client/main.cpp
+++ b/tls-client/main.cpp
@@ -415,8 +415,16 @@ int main() {
     /* The default 9600 bps is too slow to print full TLS debug info and could
      * cause the other party to time out. */
 
+    printf("\nStarting mbed-os-example-tls/tls-client\n");
+#if defined(MBED_MAJOR_VERSION)
+    printf("Using Mbed OS %d.%d.%d\n", MBED_MAJOR_VERSION, MBED_MINOR_VERSION, MBED_PATCH_VERSION);
+#else
+    printf("Using Mbed OS from master.\n");
+#endif
+
     /* Use the easy-connect lib to support multiple network bearers.   */
     /* See https://github.com/ARMmbed/easy-connect README.md for info. */
+
 #if DEBUG_LEVEL > 0
     NetworkInterface* network = easy_connect(true);
 #else

--- a/tls-client/main.cpp
+++ b/tls-client/main.cpp
@@ -202,17 +202,17 @@ public:
 
 
         /* Connect to the server */
-        mbedtls_printf("Connecting with %s\r\n", _domain);
+        mbedtls_printf("Connecting with %s\n", _domain);
         ret = _tcpsocket->connect(_domain, _port);
         if (ret != NSAPI_ERROR_OK) {
-            mbedtls_printf("Failed to connect\r\n");
-            printf("MBED: Socket Error: %d\r\n", ret);
+            mbedtls_printf("Failed to connect\n");
+            printf("MBED: Socket Error: %d\n", ret);
             _tcpsocket->close();
             return;
         }
 
        /* Start the handshake, the rest will be done in onReceive() */
-        mbedtls_printf("Starting the TLS handshake...\r\n");
+        mbedtls_printf("Starting the TLS handshake...\n");
         do {
             ret = mbedtls_ssl_handshake(&_ssl);
         } while (ret != 0 && (ret == MBEDTLS_ERR_SSL_WANT_READ ||
@@ -243,22 +243,22 @@ public:
         }
 
         /* It also means the handshake is done, time to print info */
-        printf("TLS connection to %s established\r\n", HTTPS_SERVER_NAME);
+        printf("TLS connection to %s established\n", HTTPS_SERVER_NAME);
 
         const uint32_t buf_size = 1024;
         char *buf = new char[buf_size];
         mbedtls_x509_crt_info(buf, buf_size, "\r    ",
                         mbedtls_ssl_get_peer_cert(&_ssl));
-        mbedtls_printf("Server certificate:\r\n%s\r", buf);
+        mbedtls_printf("Server certificate:\n%s", buf);
 
         uint32_t flags = mbedtls_ssl_get_verify_result(&_ssl);
         if( flags != 0 )
         {
             mbedtls_x509_crt_verify_info(buf, buf_size, "\r  ! ", flags);
-            printf("Certificate verification failed:\r\n%s\r\r\n", buf);
+            printf("Certificate verification failed:\n%s\n", buf);
         }
         else
-            printf("Certificate verification passed\r\n\r\n");
+            printf("Certificate verification passed\n\n");
 
 
         /* Read data out of the socket */
@@ -290,10 +290,10 @@ public:
         _tcpsocket->close();
 
         /* Print status messages */
-        mbedtls_printf("HTTPS: Received %d chars from server\r\n", _bpos);
-        mbedtls_printf("HTTPS: Received 200 OK status ... %s\r\n", _got200 ? "[OK]" : "[FAIL]");
-        mbedtls_printf("HTTPS: Received '%s' status ... %s\r\n", HTTPS_HELLO_STR, _gothello ? "[OK]" : "[FAIL]");
-        mbedtls_printf("HTTPS: Received message:\r\n\r\n");
+        mbedtls_printf("HTTPS: Received %d chars from server\n", _bpos);
+        mbedtls_printf("HTTPS: Received 200 OK status ... %s\n", _got200 ? "[OK]" : "[FAIL]");
+        mbedtls_printf("HTTPS: Received '%s' status ... %s\n", HTTPS_HELLO_STR, _gothello ? "[OK]" : "[FAIL]");
+        mbedtls_printf("HTTPS: Received message:\n\n");
         mbedtls_printf("%s", _buffer);
 
         delete[] buf;
@@ -306,7 +306,7 @@ protected:
     static void print_mbedtls_error(const char *name, int err) {
         char buf[128];
         mbedtls_strerror(err, buf, sizeof (buf));
-        mbedtls_printf("%s() failed: -0x%04x (%d): %s\r\n", name, -err, err, buf);
+        mbedtls_printf("%s() failed: -0x%04x (%d): %s\n", name, -err, err, buf);
     }
 
 #if DEBUG_LEVEL > 0
@@ -368,7 +368,7 @@ protected:
         if(NSAPI_ERROR_WOULD_BLOCK == recv){
             return MBEDTLS_ERR_SSL_WANT_READ;
         }else if(recv < 0){
-            mbedtls_printf("Socket recv error %d\r\n", recv);
+            mbedtls_printf("Socket recv error %d\n", recv);
             return -1;
         }else{
             return recv;
@@ -386,7 +386,7 @@ protected:
         if(NSAPI_ERROR_WOULD_BLOCK == size){
             return MBEDTLS_ERR_SSL_WANT_WRITE;
         }else if(size < 0){
-            mbedtls_printf("Socket send error %d\r\n", size);
+            mbedtls_printf("Socket send error %d\n", size);
             return -1;
         }else{
             return size;
@@ -423,7 +423,7 @@ int main() {
     /* See https://github.com/ARMmbed/easy-connect README.md for info. */
     NetworkInterface* network = easy_connect(true); /* has 1 argument, enable_logging (pass in true to log to serial port) */
     if (!network) {
-        printf("Connecting to the network failed... See serial output.\r\n");
+        printf("Connecting to the network failed... See serial output.\n");
         return 1;
     }
 

--- a/tls-client/main.cpp
+++ b/tls-client/main.cpp
@@ -421,8 +421,12 @@ int main() {
 
     /* Use the easy-connect lib to support multiple network bearers.   */
     /* See https://github.com/ARMmbed/easy-connect README.md for info. */
-    NetworkInterface* network = easy_connect(true); /* has 1 argument, enable_logging (pass in true to log to serial port) */
-    if (!network) {
+#if DEBUG_LEVEL > 0
+    NetworkInterface* network = easy_connect(true);
+#else
+    NetworkInterface* network = easy_connect(false);
+#endif /* DEBUG_LEVEL > 0 */
+    if (NULL == network) {
         printf("Connecting to the network failed... See serial output.\n");
         return 1;
     }

--- a/tls-client/mbed_app.json
+++ b/tls-client/mbed_app.json
@@ -2,8 +2,35 @@
     "macros": [
         "MBEDTLS_USER_CONFIG_FILE=\"mbedtls_entropy_config.h\""
     ],
+    "config": {
+        "network-interface":{
+            "help": "options are ETHERNET,WIFI_ESP8266,WIFI_ODIN,WIFI_REALTEK,MESH_LOWPAN_ND,MESH_THREAD",
+            "value": "ETHERNET"
+        },
+        "esp8266-tx": {
+            "help": "Pin used as TX (connects to ESP8266 RX)",
+            "value": "PTD3"
+        },
+        "esp8266-rx": {
+            "help": "Pin used as RX (connects to ESP8266 TX)",
+            "value": "PTD2"
+        },
+        "esp8266-debug": {
+            "value": true
+        },
+        "wifi-ssid": {
+            "value": "\"SSID\""
+        },
+        "wifi-password": {
+            "value": "\"Password\""
+        }
+    },
     "target_overrides": {
-        "UBLOX_EVK_ODIN_W2": {
+        "*": {
+            "platform.stdio-baud-rate": 115200,
+            "platform.stdio-convert-newlines": true
+        },
+            "UBLOX_EVK_ODIN_W2": {
             "target.device_has_remove": ["EMAC"]
         }
     }

--- a/tls-client/mbed_app.json
+++ b/tls-client/mbed_app.json
@@ -4,7 +4,7 @@
     ],
     "config": {
         "network-interface":{
-            "help": "options are ETHERNET,WIFI_ESP8266,WIFI_ODIN,WIFI_REALTEK,MESH_LOWPAN_ND,MESH_THREAD",
+            "help": "options are ETHERNET, WIFI_ESP8266, WIFI_ODIN, WIFI_IDW01M1, WIFI_RTW, MESH_LOWPAN_ND, MESH_THREAD",
             "value": "ETHERNET"
         },
         "esp8266-tx": {
@@ -27,10 +27,9 @@
     },
     "target_overrides": {
         "*": {
-            "platform.stdio-baud-rate": 115200,
             "platform.stdio-convert-newlines": true
         },
-            "UBLOX_EVK_ODIN_W2": {
+        "UBLOX_EVK_ODIN_W2": {
             "target.device_has_remove": ["EMAC"]
         }
     }

--- a/tls-client/mbed_app.json
+++ b/tls-client/mbed_app.json
@@ -1,5 +1,6 @@
 {
     "macros": [
+        "MBED_CONF_APP_MAIN_STACK_SIZE=4096",
         "MBEDTLS_USER_CONFIG_FILE=\"mbedtls_entropy_config.h\""
     ],
     "config": {
@@ -27,7 +28,8 @@
     },
     "target_overrides": {
         "*": {
-            "platform.stdio-convert-newlines": true
+             "platform.stdio-baud-rate": 9600,
+             "platform.stdio-convert-newlines": true
         },
         "UBLOX_EVK_ODIN_W2": {
             "target.device_has_remove": ["EMAC"]


### PR DESCRIPTION
Take easy-connect into use with the tls-client, so that one can
more easily (i.e. w/o modifying the actual main.cpp) use multiple
network stacks (just modify the mbed_app.json).