### PR TITLE
Updating mbed-os to mbed-os-5.5.5

### DIFF
--- a/authcrypt/mbed-os.lib
+++ b/authcrypt/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#4c256f04596179699c4f14b6863b07cc024ca9be
+https://github.com/ARMmbed/mbed-os/#db4be94693c3a873cfa0c025a5ad2e62b86a8474

--- a/benchmark/mbed-os.lib
+++ b/benchmark/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#4c256f04596179699c4f14b6863b07cc024ca9be
+https://github.com/ARMmbed/mbed-os/#db4be94693c3a873cfa0c025a5ad2e62b86a8474

--- a/hashing/mbed-os.lib
+++ b/hashing/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#4c256f04596179699c4f14b6863b07cc024ca9be
+https://github.com/ARMmbed/mbed-os/#db4be94693c3a873cfa0c025a5ad2e62b86a8474

--- a/tls-client/mbed-os.lib
+++ b/tls-client/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#4c256f04596179699c4f14b6863b07cc024ca9be
+https://github.com/ARMmbed/mbed-os/#db4be94693c3a873cfa0c025a5ad2e62b86a8474


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.5.5 . 