### PR TITLE
Updating mbed-os to mbed-os-5.5.7

### DIFF
--- a/authcrypt/mbed-os.lib
+++ b/authcrypt/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#98ba8acb83cfc65f30a8a0771a27c71443ab093a
+https://github.com/ARMmbed/mbed-os/#ca661f9d28526ca8f874b05432493a489c9671ea

--- a/benchmark/mbed-os.lib
+++ b/benchmark/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#98ba8acb83cfc65f30a8a0771a27c71443ab093a
+https://github.com/ARMmbed/mbed-os/#ca661f9d28526ca8f874b05432493a489c9671ea

--- a/hashing/mbed-os.lib
+++ b/hashing/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#98ba8acb83cfc65f30a8a0771a27c71443ab093a
+https://github.com/ARMmbed/mbed-os/#ca661f9d28526ca8f874b05432493a489c9671ea

--- a/tls-client/mbed-os.lib
+++ b/tls-client/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#98ba8acb83cfc65f30a8a0771a27c71443ab093a
+https://github.com/ARMmbed/mbed-os/#ca661f9d28526ca8f874b05432493a489c9671ea


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.5.7 . 