### PR TITLE
mbed-os-5.6-oob: Change mbed server address to os.mbed.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains a collection of mbed TLS example applications based on 
 # Getting started
 
 ## Required hardware
-* An [FRDM-K64F](http://developer.mbed.org/platforms/FRDM-K64F/) development board.
+* An [FRDM-K64F](http://os.mbed.com/platforms/FRDM-K64F/) development board.
 * A micro-USB cable.
 
 ### Other hardware
@@ -18,13 +18,13 @@ If your board has no hardware entropy source or its entropy source is not integr
 
 ## Required software
 * [mbed CLI](https://github.com/ARMmbed/mbed-cli) - to build the example program. To learn how to build mbed OS applications with mbed CLI, see the [user guide](https://github.com/ARMmbed/mbed-cli/blob/master/README.md)
-* [Serial port monitor](https://developer.mbed.org/handbook/SerialPC#host-interface-and-terminal-applications).
+* [Serial port monitor](https://os.mbed.com/handbook/SerialPC#host-interface-and-terminal-applications).
 
-An alternative to mbed CLI is to use the [mbed Online Compiler](https://developer.mbed.org/compiler/). In this case, you need to import the example projects from [mbed developer](https://developer.mbed.org/) to your mbed Online Compiler session using the links below:
-* [authcrypt](https://developer.mbed.org/teams/mbed-os-examples/code/mbed-os-example-tls-authcrypt)
-* [benchmark](https://developer.mbed.org/teams/mbed-os-examples/code/mbed-os-example-tls-benchmark)
-* [hashing](https://developer.mbed.org/teams/mbed-os-examples/code/mbed-os-example-tls-hashing)
-* [tls-client](https://developer.mbed.org/teams/mbed-os-examples/code/mbed-os-example-tls-tls-client)
+An alternative to mbed CLI is to use the [mbed Online Compiler](https://os.mbed.com/compiler/). In this case, you need to import the example projects from [mbed developer](https://os.mbed.com/) to your mbed Online Compiler session using the links below:
+* [authcrypt](https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-tls-authcrypt)
+* [benchmark](https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-tls-benchmark)
+* [hashing](https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-tls-hashing)
+* [tls-client](https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-tls-tls-client)
 
 ## Building and running the examples
 
@@ -53,9 +53,9 @@ Please browse the subdirectories for specific documentation.
 * [authcrypt](./authcrypt/README.md): performs authenticated encryption and authenticated decryption of a buffer.
 * [benchmark](./benchmark/README.md): benchmarks the various cryptographic primitives offered by mbed TLS.
 * [hashing](./hashing/README.md): performs hashing of a buffer with SHA-256 using various APIs.
-* [tls-client](./tls-client/README.md): downloads a file from an HTTPS server (developer.mbed.org) and looks for a specific string in that file.
+* [tls-client](./tls-client/README.md): downloads a file from an HTTPS server (os.mbed.com) and looks for a specific string in that file.
 
-The application prints debug messages over the serial port, so you can monitor its activity with a serial terminal emulator. Start the [serial terminal emulator](https://developer.mbed.org/handbook/Terminals) and connect to the [virtual serial port](https://developer.mbed.org/handbook/SerialPC#host-interface-and-terminal-applications) presented by FRDM-K64F. Use the following settings:
+The application prints debug messages over the serial port, so you can monitor its activity with a serial terminal emulator. Start the [serial terminal emulator](https://os.mbed.com/handbook/Terminals) and connect to the [virtual serial port](https://os.mbed.com/handbook/SerialPC#host-interface-and-terminal-applications) presented by FRDM-K64F. Use the following settings:
 
 * 9600 baud.
 * 8N1.

--- a/authcrypt/README.md
+++ b/authcrypt/README.md
@@ -6,7 +6,7 @@ This application performs authenticated encryption and authenticated decryption 
 
 Set up your environment if you have not done so already. For instructions, refer to the [main readme](../README.md).
 
-You can also compile this example with the [mbed Online Compiler](https://developer.mbed.org/compiler/) by using [this project](https://developer.mbed.org/teams/mbed-os-examples/code/mbed-os-example-tls-authcrypt).
+You can also compile this example with the [mbed Online Compiler](https://os.mbed.com/compiler/) by using [this project](https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-tls-authcrypt).
 
 ## Monitoring the application
 

--- a/authcrypt/mbed-os.lib
+++ b/authcrypt/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#98ba8acb83cfc65f30a8a0771a27c71443ab093a
+https://github.com/ARMmbed/mbed-os/#a4056fb8bf3ee10b8e037d332f8fbd0c68169ef1

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -6,7 +6,7 @@ This application benchmarks the various cryptographic primitives offered by mbed
 
 Set up your environment if you have not done so already. For instructions, refer to the [main readme](../README.md).
 
-You can also compile this example with the [mbed Online Compiler](https://developer.mbed.org/compiler/) by using [this project](https://developer.mbed.org/teams/mbed-os-examples/code/mbed-os-example-tls-benchmark).
+You can also compile this example with the [mbed Online Compiler](https://os.mbed.com/compiler/) by using [this project](https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-tls-benchmark).
 
 ## Monitoring the application
 

--- a/benchmark/mbed-os.lib
+++ b/benchmark/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#98ba8acb83cfc65f30a8a0771a27c71443ab093a
+https://github.com/ARMmbed/mbed-os/#a4056fb8bf3ee10b8e037d332f8fbd0c68169ef1

--- a/hashing/README.md
+++ b/hashing/README.md
@@ -6,7 +6,7 @@ This application performs hashing of a buffer with SHA-256 using various APIs. I
 
 Set up your environment if you have not done so already. For instructions, refer to the [main readme](../README.md).
 
-You can also compile this example with the [mbed Online Compiler](https://developer.mbed.org/compiler/) by using [this project](https://developer.mbed.org/teams/mbed-os-examples/code/mbed-os-example-tls-hashing).
+You can also compile this example with the [mbed Online Compiler](https://os.mbed.com/compiler/) by using [this project](https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-tls-hashing).
 
 ## Monitoring the application
 

--- a/hashing/mbed-os.lib
+++ b/hashing/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#98ba8acb83cfc65f30a8a0771a27c71443ab093a
+https://github.com/ARMmbed/mbed-os/#a4056fb8bf3ee10b8e037d332f8fbd0c68169ef1

--- a/tls-client/README.md
+++ b/tls-client/README.md
@@ -39,7 +39,6 @@ Server certificate:
     RSA key size      : 2048 bits
     basic constraints : CA=false
     subject alt name  : *.mbed.com, mbed.org, *.mbed.org, mbed.com
-    subject alt name  : *.mbed.com, mbed.org, *.mbed.org, mbed.com
     key usage         : Digital Signature, Key Encipherment
     ext key usage     : TLS Web Server Authentication, TLS Web Client Authentication
 Certificate verification passed

--- a/tls-client/README.md
+++ b/tls-client/README.md
@@ -1,12 +1,12 @@
 # HTTPS File Download Example for TLS Client on mbed OS
 
-This application downloads a file from an HTTPS server (developer.mbed.org) and looks for a specific string in that file.
+This application downloads a file from an HTTPS server (os.mbed.com) and looks for a specific string in that file.
 
 ## Getting started
 
 Set up your environment if you have not done so already. For instructions, refer to the [main readme](../README.md).
 
-You can also compile this example with the [mbed Online Compiler](https://developer.mbed.org/compiler/) by using [this project](https://developer.mbed.org/teams/mbed-os-examples/code/mbed-os-example-tls-tls-client).
+You can also compile this example with the [mbed Online Compiler](https://os.mbed.com/compiler/) by using [this project](https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-tls-tls-client).
 
 ## Required hardware
 
@@ -14,7 +14,7 @@ This example also requires an Ethernet cable and connection to the internet addi
 
 The networking stack used in this example requires TLS functionality to be enabled on mbed TLS. On devices where hardware entropy is not present, TLS is disabled by default. This would result in compile time or linking failures.
 
-To learn why entropy is required, read the [TLS Porting guide](https://docs.mbed.com/docs/mbed-os-handbook/en/5.2/advanced/tls_porting/).
+To learn why entropy is required, read the [TLS Porting guide](https://docs.mbed.com/docs/mbed-os-handbook/en/latest/advanced/tls_porting/).
 
 ## Monitoring the application
 
@@ -24,42 +24,42 @@ The output in the terminal window should be similar to this:
 
 ```
 Using Ethernet LWIP
-Client IP Address is 10.2.203.43
-Connecting with developer.mbed.org
+Client IP Address is 172.16.8.12
+Connecting with os.mbed.com
 Starting the TLS handshake...
-TLS connection to developer.mbed.org established
+TLS connection to os.mbed.com established
 Server certificate:
     cert. version     : 3
-    serial number     : 11:21:B8:47:9B:21:6C:B1:C6:AF:BC:5D:0C:19:52:DC:D7:C3
+    serial number     : 65:7B:6D:8D:15:A5:B6:86:87:6B:5E:BC
     issuer name       : C=BE, O=GlobalSign nv-sa, CN=GlobalSign Organization Validation CA - SHA256 - G2
     subject name      : C=GB, ST=Cambridgeshire, L=Cambridge, O=ARM Ltd, CN=*.mbed.com
-    issued  on        : 2016-03-03 12:26:08
-    expires on        : 2017-04-05 10:31:02
+    issued  on        : 2017-04-03 13:54:02
+    expires on        : 2018-05-06 10:31:02
     signed using      : RSA with SHA-256
     RSA key size      : 2048 bits
     basic constraints : CA=false
+    subject alt name  : *.mbed.com, mbed.org, *.mbed.org, mbed.com
     subject alt name  : *.mbed.com, mbed.org, *.mbed.org, mbed.com
     key usage         : Digital Signature, Key Encipherment
     ext key usage     : TLS Web Server Authentication, TLS Web Client Authentication
 Certificate verification passed
 
-HTTPS: Received 439 chars from server
 HTTPS: Received 200 OK status ... [OK]
 HTTPS: Received 'Hello world!' status ... [OK]
 HTTPS: Received message:
 
 HTTP/1.1 200 OK
-Server: nginx/1.7.10
-Date: Wed, 20 Jul 2016 10:00:35 GMT
+Server: nginx/1.11.12
+Date: Mon, 18 Sep 2017 12:54:59 GMT
 Content-Type: text/plain
 Content-Length: 14
 Connection: keep-alive
 Last-Modified: Fri, 27 Jul 2012 13:30:34 GMT
 Accept-Ranges: bytes
 Cache-Control: max-age=36000
-Expires: Wed, 20 Jul 2016 20:00:35 GMT
-X-Upstream-L3: 172.17.0.3:80
-X-Upstream-L2: developer-sjc-indigo-1-nginx
+Expires: Mon, 18 Sep 2017 22:54:59 GMT
+X-Upstream-L3: 172.17.0.4:80
+X-Upstream-L2: developer-sjc-cyan-1-nginx
 Strict-Transport-Security: max-age=31536000; includeSubdomains
 
 Hello world!
@@ -81,9 +81,9 @@ To print out more debug information about the TLS connection, edit the file `mai
 The TLS connection can fail with an error similar to:
 
     mbedtls_ssl_write() failed: -0x2700 (-9984): X509 - Certificate verification failed, e.g. CRL, CA or signature check failed
-    Failed to fetch /media/uploads/mbed_official/hello.txt from developer.mbed.org:443
+    Failed to fetch /media/uploads/mbed_official/hello.txt from os.mbed.com:443
 
-This probably means you need to update the contents of the `SSL_CA_PEM` constant (this can happen if you modify `HTTPS_SERVER_NAME`, or when `developer.mbed.org` switches to a new CA when updating its certificate).
+This probably means you need to update the contents of the `SSL_CA_PEM` constant (this can happen if you modify `HTTPS_SERVER_NAME`, or when `os.mbed.com` switches to a new CA when updating its certificate).
 
 Another possible reason for this error is a proxy providing a different certificate. Proxies can be used in some network configurations or for performing man-in-the-middle attacks. If you choose to ignore this error and proceed with the connection anyway, you can change the definition of `UNSAFE` near the top of the file from 0 to 1.
 

--- a/tls-client/main.cpp
+++ b/tls-client/main.cpp
@@ -21,7 +21,7 @@
 
 /** \file main.cpp
  *  \brief An example TLS Client application
- *  This application sends an HTTPS request to developer.mbed.org and searches for a string in
+ *  This application sends an HTTPS request to os.mbed.com and searches for a string in
  *  the result.
  *
  *  This example is implemented as a logic class (HelloHTTPS) wrapping a TCP socket.
@@ -50,7 +50,7 @@
 
 namespace {
 
-const char *HTTPS_SERVER_NAME = "developer.mbed.org";
+const char *HTTPS_SERVER_NAME = "os.mbed.com";
 const int HTTPS_SERVER_PORT = 443;
 const int RECV_BUFFER_SIZE = 600;
 
@@ -64,7 +64,7 @@ const char *HTTPS_HELLO_STR = "Hello world!";
 const char *DRBG_PERS = "mbed TLS helloword client";
 
 /* List of trusted root CA certificates
- * currently only GlobalSign, the CA for developer.mbed.org
+ * currently only GlobalSign, the CA for os.mbed.com
  *
  * To add more than one root, just concatenate them.
  */

--- a/tls-client/mbed-os.lib
+++ b/tls-client/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#98ba8acb83cfc65f30a8a0771a27c71443ab093a
+https://github.com/ARMmbed/mbed-os/#a4056fb8bf3ee10b8e037d332f8fbd0c68169ef1


### PR DESCRIPTION
This is a port of PR #117 to the mbed OS 5.6 OOB branch.

@adbridge @Patater: The same changes were also merged to the master branch and this is the requested port to the OOB branch to enable future testing rounds.