### PR TITLE
Updating mbed-os to mbed-os-5.6.1

### DIFF
--- a/authcrypt/mbed-os.lib
+++ b/authcrypt/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5499db1e815b035c2039b6f1e7cbcbf1fd7e0f19
+https://github.com/ARMmbed/mbed-os/#cc7556a92fb9320f4bebb190c6e1315af116c50c

--- a/benchmark/mbed-os.lib
+++ b/benchmark/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5499db1e815b035c2039b6f1e7cbcbf1fd7e0f19
+https://github.com/ARMmbed/mbed-os/#cc7556a92fb9320f4bebb190c6e1315af116c50c

--- a/hashing/mbed-os.lib
+++ b/hashing/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5499db1e815b035c2039b6f1e7cbcbf1fd7e0f19
+https://github.com/ARMmbed/mbed-os/#cc7556a92fb9320f4bebb190c6e1315af116c50c

--- a/tls-client/mbed-os.lib
+++ b/tls-client/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5499db1e815b035c2039b6f1e7cbcbf1fd7e0f19
+https://github.com/ARMmbed/mbed-os/#cc7556a92fb9320f4bebb190c6e1315af116c50c


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.6.1 . 