### PR TITLE
Updating mbed-os to mbed-os-5.6.4

### DIFF
--- a/authcrypt/mbed-os.lib
+++ b/authcrypt/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e62a1b9236b44e70ae3b0902dc538481c04d455b
+https://github.com/ARMmbed/mbed-os/#78474a5129e18e136cc7e872adbaa5b74fbb8f6a

--- a/benchmark/mbed-os.lib
+++ b/benchmark/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e62a1b9236b44e70ae3b0902dc538481c04d455b
+https://github.com/ARMmbed/mbed-os/#78474a5129e18e136cc7e872adbaa5b74fbb8f6a

--- a/hashing/mbed-os.lib
+++ b/hashing/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e62a1b9236b44e70ae3b0902dc538481c04d455b
+https://github.com/ARMmbed/mbed-os/#78474a5129e18e136cc7e872adbaa5b74fbb8f6a

--- a/tls-client/mbed-os.lib
+++ b/tls-client/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e62a1b9236b44e70ae3b0902dc538481c04d455b
+https://github.com/ARMmbed/mbed-os/#78474a5129e18e136cc7e872adbaa5b74fbb8f6a


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.6.4 . 