### PR TITLE
Updating mbed-os to mbed-os-5.6.5

### DIFF
--- a/authcrypt/mbed-os.lib
+++ b/authcrypt/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#78474a5129e18e136cc7e872adbaa5b74fbb8f6a
+https://github.com/ARMmbed/mbed-os/#34b61d1612aaec2e5d61a8a43c9764bc2fe8aac0

--- a/benchmark/mbed-os.lib
+++ b/benchmark/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#78474a5129e18e136cc7e872adbaa5b74fbb8f6a
+https://github.com/ARMmbed/mbed-os/#34b61d1612aaec2e5d61a8a43c9764bc2fe8aac0

--- a/hashing/mbed-os.lib
+++ b/hashing/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#78474a5129e18e136cc7e872adbaa5b74fbb8f6a
+https://github.com/ARMmbed/mbed-os/#34b61d1612aaec2e5d61a8a43c9764bc2fe8aac0

--- a/tls-client/mbed-os.lib
+++ b/tls-client/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#78474a5129e18e136cc7e872adbaa5b74fbb8f6a
+https://github.com/ARMmbed/mbed-os/#34b61d1612aaec2e5d61a8a43c9764bc2fe8aac0


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.6.5 . 