### PR TITLE
Updating mbed-os to mbed-os-5.7.1

### DIFF
--- a/authcrypt/mbed-os.lib
+++ b/authcrypt/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5f6572179d66ce4c09d6517b659ac51133cc980d
+https://github.com/ARMmbed/mbed-os/#2b4ff78ab0a52ef1dc3f2998908453c595e2b2c0

--- a/benchmark/mbed-os.lib
+++ b/benchmark/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5f6572179d66ce4c09d6517b659ac51133cc980d
+https://github.com/ARMmbed/mbed-os/#2b4ff78ab0a52ef1dc3f2998908453c595e2b2c0

--- a/hashing/mbed-os.lib
+++ b/hashing/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5f6572179d66ce4c09d6517b659ac51133cc980d
+https://github.com/ARMmbed/mbed-os/#2b4ff78ab0a52ef1dc3f2998908453c595e2b2c0

--- a/tls-client/mbed-os.lib
+++ b/tls-client/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5f6572179d66ce4c09d6517b659ac51133cc980d
+https://github.com/ARMmbed/mbed-os/#2b4ff78ab0a52ef1dc3f2998908453c595e2b2c0


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.7.1 . 