### PR TITLE
Update easy-connect, remove .mbedignore

### DIFF
--- a/tls-client/.mbedignore
+++ b/tls-client/.mbedignore
@@ -1,7 +1,0 @@
-easy-connect/atmel-rf-driver/*
-easy-connect/mcr20a-rf-driver/*
-easy-connect/esp8266-driver/*
-easy-connect/stm-spirit1-rf-driver/*
-easy-connect/wifi-x-nucleo-idw01m1/*
-
-

--- a/tls-client/easy-connect.lib
+++ b/tls-client/easy-connect.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/easy-connect/#e44b96188010dc8d453721ba913f9ac9d9c3d6c5
+https://github.com/ARMmbed/easy-connect/#4e608305251d18851afc500dbbe704cca51db624


### PR DESCRIPTION
As there have been fixes to easy-connect & components it uses (mesh)
we can get rid of the `.mbedignore` -file. There is also support for one
new wifi-stack (WizFi310).