### PR TITLE
Add heap statistics to tls-example

### DIFF
--- a/tls-client/README.md
+++ b/tls-client/README.md
@@ -92,6 +92,33 @@ Another possible reason for this error is a proxy providing a different certific
 
 **Warning:** this removes all security against a possible active attacker, so use at your own risk or for debugging only!
 
+## Heap statistics
+
+If you compile the application with `DHEAP_STATS_ENABLED=1` option will enable the heap statistics printouts. 
+
+Mbed OS feature a heap statistics monitoring feature and you can measure the heap memory consumption (current and maximum). You can then clearly see from the printouts how much heap memory is consumed by the operations.
+
+Example printout looks like this:
+
+```
+Starting mbed-os-example-tls/tls-client
+**** heap_stats at Starting
+**** current_size: 1024
+**** max_size : 1024
+```
+
+at startup we consume 1 kilobyte of heap. 
+
+```
+**** heap_stats at Finished
+**** current_size: 2960
+**** max_size : 53131
+```
+
+However, at the end we can see our peak heap consumption was over 53 kilobytes.
+
+More information on Mbed OS memory statistics available in [documentation](https://docs.mbed.com/docs/mbed-os-handbook/en/5.2/advanced/runtime_stats/).
+
 ## Troubleshooting
 
 If you have problems, you can review the [documentation](https://os.mbed.com/docs/latest/tutorials/debugging.html) for suggestions on what could be wrong and how to fix it.

--- a/tls-client/main.cpp
+++ b/tls-client/main.cpp
@@ -32,7 +32,9 @@
 /* Change to a number between 1 and 4 to debug the TLS connection */
 #define DEBUG_LEVEL 0
 
+#include <inttypes.h>
 #include "mbed.h"
+#include "mbed_stats.h"
 #include "easy-connect.h"
 
 #include "mbedtls/platform.h"
@@ -409,13 +411,32 @@ protected:
 };
 
 /**
+ * Print current heap statistics
+ * NOTE! If -DMBED_HEAP_STATS_ENABLED was not given as compilation parameter, this function is void.
+ * IN: event - char ptr to a describing event.
+ */
+void heap_stats(char *event)
+{
+#ifdef MBED_HEAP_STATS_ENABLED
+    printf("**** heap_stats at %s\n", event);
+    mbed_stats_heap_t stats;
+    mbed_stats_heap_get(&stats);
+    printf("**** current_size: %" PRIu32 "\n", stats.current_size);
+    printf("**** max_size    : %" PRIu32 "\n", stats.max_size);
+#endif // MBED_HEAP_STATS_ENABLED
+}
+
+
+/**
  * The main loop of the HTTPS Hello World test
  */
 int main() {
     /* The default 9600 bps is too slow to print full TLS debug info and could
      * cause the other party to time out. */
 
+
     printf("\nStarting mbed-os-example-tls/tls-client\n");
+    heap_stats("Starting");
 #if defined(MBED_MAJOR_VERSION)
     printf("Using Mbed OS %d.%d.%d\n", MBED_MAJOR_VERSION, MBED_MINOR_VERSION, MBED_PATCH_VERSION);
 #else
@@ -434,8 +455,15 @@ int main() {
         printf("Connecting to the network failed... See serial output.\n");
         return 1;
     }
+    heap_stats("Network up");
 
     HelloHTTPS *hello = new HelloHTTPS(HTTPS_SERVER_NAME, HTTPS_SERVER_PORT, network);
+    heap_stats("HelloHTTPS class created");
     hello->startTest(HTTPS_PATH);
+    heap_stats("HelloHTTPS run");
     delete hello;
+
+    printf("\nAll done.\n");
+    heap_stats("Finished");
 }
+


### PR DESCRIPTION
This highlights the heap memory usage in an easy-to-use way.
You can quite clearly see how the heap usage peaks up.