### PR TITLE
Warn about improper error reporting by ATCAECC508A driver

### DIFF
--- a/pk_sign/README.md
+++ b/pk_sign/README.md
@@ -1,0 +1,6 @@
+# PK Sign sample
+This sample demonstrates signature creation using Mbed TLS opaque keys feature. This demo version demonstrates only ECDSA signing using hardware crypto engine ATCAECC508A. This example requires commissioning ATCAECC508A.
+
+## Commission ATCAECC508A
+For this example an ATCAECC508A device must be commissioned and connected to the Mbed target on I2C interface. Please see documentation [here](https://github.com/ARMmbed/mbed-os/tree/feature-opaque-keys/features/atcryptoauth#commissioning-application) about it. 
+**Note:** The error reporting is not propoer in case of the device not connected or not commissioned. Example may report a memory allocation failure in these situations. Also, the Atmel Crypto Auth Pro device that comes with ATCAECC508A needs a jumper change before use.

--- a/pk_sign/README.md
+++ b/pk_sign/README.md
@@ -4,3 +4,6 @@ This sample demonstrates signature creation using Mbed TLS opaque keys feature. 
 ## Commission ATCAECC508A
 For this example an ATCAECC508A device must be commissioned and connected to the Mbed target on I2C interface. Please see documentation [here](https://github.com/ARMmbed/mbed-os/tree/feature-opaque-keys/features/atcryptoauth#commissioning-application) about it. 
 **Note:** The error reporting is not propoer in case of the device not connected or not commissioned. Example may report a memory allocation failure in these situations. Also, the Atmel Crypto Auth Pro device that comes with ATCAECC508A needs a jumper change before use.
+
+## Building the sample
+ATECC508A requires I2C interface. It is present in most of the Mbed Platforms. However, not all platforms define I2C_SDA and I2C_SCL pins uniformaly. Hence, code in [mbed-os/features/atcryptoauth/ATCAFactory.cpp](https://github.com/ARMmbed/mbed-os/blob/feature-opaque-keys/features/atcryptoauth/ATCAFactory.cpp#L23) limits the feature to platform K64F. In order to build for any other target please enable it in the code and provide target specific I2C_SDA and I2C_SCL pin names.

--- a/pk_verify/README.md
+++ b/pk_verify/README.md
@@ -1,0 +1,6 @@
+# PK Verify sample
+This sample demonstrates signature creation and verification using Mbed TLS opaque keys feature. This demo version demonstrates only ECDSA signing using hardware crypto engine ATCAECC508A. This example requires commissioning ATCAECC508A.
+
+## Commission ATCAECC508A
+For this example an ATCAECC508A device must be commissioned and connected to the Mbed target on I2C interface. Please see documentation [here](https://github.com/ARMmbed/mbed-os/tree/feature-opaque-keys/features/atcryptoauth#commissioning-application) about it. 
+**Note:** The error reporting is not propoer in case of the device not connected or not commissioned. Example may report a memory allocation failure in these situations. Also, the Atmel Crypto Auth Pro device that comes with ATCAECC508A needs a jumper change before use.

--- a/pk_verify/README.md
+++ b/pk_verify/README.md
@@ -4,3 +4,6 @@ This sample demonstrates signature creation and verification using Mbed TLS opaq
 ## Commission ATCAECC508A
 For this example an ATCAECC508A device must be commissioned and connected to the Mbed target on I2C interface. Please see documentation [here](https://github.com/ARMmbed/mbed-os/tree/feature-opaque-keys/features/atcryptoauth#commissioning-application) about it. 
 **Note:** The error reporting is not propoer in case of the device not connected or not commissioned. Example may report a memory allocation failure in these situations. Also, the Atmel Crypto Auth Pro device that comes with ATCAECC508A needs a jumper change before use.
+
+## Building the sample
+ATECC508A requires I2C interface. It is present in most of the Mbed Platforms. However, not all platforms define I2C_SDA and I2C_SCL pins uniformaly. Hence, code in [mbed-os/features/atcryptoauth/ATCAFactory.cpp](https://github.com/ARMmbed/mbed-os/blob/feature-opaque-keys/features/atcryptoauth/ATCAFactory.cpp#L23) limits the feature to platform K64F. In order to build for any other target please enable it in the code and provide target specific I2C_SDA and I2C_SCL pin names.

--- a/tls-client-with-client-authentication/README.md
+++ b/tls-client-with-client-authentication/README.md
@@ -1,14 +1,19 @@
 # TLS Client with Opaque keys
-This sample demonstrates a TLS client sample application that performs client authentication. It uses a hardware cryptographic engine with the opaque keys feature for ECDSA signing and verification. In this first version this sample is tied to specific device [ATCAECC508A](https://www.microchip.com/wwwproducts/en/ATECC508A). The driver is developed inside [mbed-os](https://github.com/ARMmbed/mbed-os/pull/6104).
+This sample demonstrates a TLS client sample application that performs client authentication. It uses a hardware cryptographic engine with the opaque keys feature for ECDSA signing and verification. In this first version this sample is tied to specific device [ATCAECC508A](https://www.microchip.com/wwwproducts/en/ATECC508A). The driver is developed inside [mbed-os](https://github.com/ARMmbed/mbed-os/tree/feature-opaque-keys/features/atcryptoauth).
 In future the opaque keys interface will be made generic to interface any cryptographic engine with this sample.
 
 ## Execution environment
 This sample demonstrates use of hardware cryptographic engines that cannot have same hard-coded private key for testing. Hence for executing this sample new set of keys, certificates and host setup is required. Since ATCAECC508A only supports ECDSA and SHA-256, this sample runs against an SSL server configured with ECDSA and SHA-256 ciphersuites. The following things are required for the test setup:
 
+- Commission ATCAECC508A
 - Client certificate
 - Server CA cert.
 - Server certificate signed by CA.
 - Server certificate private key.
+
+## Commission ATCAECC508A
+For this example an ATCAECC508A device must be commissioned and connected to the Mbed target on I2C interface. Please see documentation [here](https://github.com/ARMmbed/mbed-os/tree/feature-opaque-keys/features/atcryptoauth#commissioning-application) about it. 
+**Note:** The error reporting is not propoer in case of the device not connected or not commissioned. Example may report a memory allocation failure in these situations. Also, the Atmel Crypto Auth Pro device that comes with ATCAECC508A needs a jumper change before use.
 
 ## Client certificate
 A self signed certificate can be generated using [modified](https://github.com/ARMmbed/mbedtls/pull/1360) ```cert_write.exe``` application. Steps are as follows:

--- a/tls-client-with-client-authentication/README.md
+++ b/tls-client-with-client-authentication/README.md
@@ -5,11 +5,15 @@ In future the opaque keys interface will be made generic to interface any crypto
 ## Execution environment
 This sample demonstrates use of hardware cryptographic engines that cannot have same hard-coded private key for testing. Hence for executing this sample new set of keys, certificates and host setup is required. Since ATCAECC508A only supports ECDSA and SHA-256, this sample runs against an SSL server configured with ECDSA and SHA-256 ciphersuites. The following things are required for the test setup:
 
+- Building mbed-os application
 - Commission ATCAECC508A
 - Client certificate
 - Server CA cert.
 - Server certificate signed by CA.
 - Server certificate private key.
+
+## Building mbed-os application
+ATECC508A requires I2C interface. It is present in most of the Mbed Platforms. However, not all platforms define I2C_SDA and I2C_SCL pins uniformaly. Hence, code in [mbed-os/features/atcryptoauth/ATCAFactory.cpp](https://github.com/ARMmbed/mbed-os/blob/feature-opaque-keys/features/atcryptoauth/ATCAFactory.cpp#L23) limits the feature to platform K64F. In order to build for any other target please enable it in the code and provide target specific I2C_SDA and I2C_SCL pin names.
 
 ## Commission ATCAECC508A
 For this example an ATCAECC508A device must be commissioned and connected to the Mbed target on I2C interface. Please see documentation [here](https://github.com/ARMmbed/mbed-os/tree/feature-opaque-keys/features/atcryptoauth#commissioning-application) about it. 


### PR DESCRIPTION
ATCAECC508A driver may not report device initialisation errors properly when device not connected to the Mbed platform or it is not commissioned.
Warning added here is temporary and will be removed once driver is fixed. Driver is not fixed in the demo release now since the time to merge in mbed-os is longer. 