### PR TITLE
Updating mbed-os to mbed-os-5.7.7

### DIFF
--- a/authcrypt/mbed-os.lib
+++ b/authcrypt/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#91e6db1ea251ffcc973001ed90477f42fdca5751
+https://github.com/ARMmbed/mbed-os/#16bac101a6b7b4724023dcf86ece1548e3a23cbf

--- a/benchmark/mbed-os.lib
+++ b/benchmark/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#91e6db1ea251ffcc973001ed90477f42fdca5751
+https://github.com/ARMmbed/mbed-os/#16bac101a6b7b4724023dcf86ece1548e3a23cbf

--- a/hashing/mbed-os.lib
+++ b/hashing/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#91e6db1ea251ffcc973001ed90477f42fdca5751
+https://github.com/ARMmbed/mbed-os/#16bac101a6b7b4724023dcf86ece1548e3a23cbf

--- a/tls-client/mbed-os.lib
+++ b/tls-client/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#91e6db1ea251ffcc973001ed90477f42fdca5751
+https://github.com/ARMmbed/mbed-os/#16bac101a6b7b4724023dcf86ece1548e3a23cbf


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.7.7 . 