### PR TITLE
Updating mbed-os to mbed-os-5.8.1

### DIFF
--- a/authcrypt/mbed-os.lib
+++ b/authcrypt/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#16bac101a6b7b4724023dcf86ece1548e3a23cbf
+https://github.com/ARMmbed/mbed-os/#addec7ba10054be03849eff58a1d17f157391e7d

--- a/benchmark/mbed-os.lib
+++ b/benchmark/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#16bac101a6b7b4724023dcf86ece1548e3a23cbf
+https://github.com/ARMmbed/mbed-os/#addec7ba10054be03849eff58a1d17f157391e7d

--- a/hashing/mbed-os.lib
+++ b/hashing/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#16bac101a6b7b4724023dcf86ece1548e3a23cbf
+https://github.com/ARMmbed/mbed-os/#addec7ba10054be03849eff58a1d17f157391e7d

--- a/tls-client/mbed-os.lib
+++ b/tls-client/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#16bac101a6b7b4724023dcf86ece1548e3a23cbf
+https://github.com/ARMmbed/mbed-os/#addec7ba10054be03849eff58a1d17f157391e7d


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.8.1 . 