### PR TITLE
Add platform setup and teardown support

### DIFF
--- a/authcrypt/main.cpp
+++ b/authcrypt/main.cpp
@@ -24,6 +24,11 @@
 #include "mbedtls/platform.h"
 
 int main() {
+    mbedtls_platform_context platform_ctx;
+    if(mbedtls_platform_setup(&platform_ctx)) {
+        return -1;
+    }
+
     int exit_code = MBEDTLS_EXIT_SUCCESS;
     Authcrypt *authcrypt = new Authcrypt();
 
@@ -34,5 +39,6 @@ int main() {
 
     delete authcrypt;
 
+    mbedtls_platform_teardown(&platform_ctx);
     return exit_code;
 }

--- a/benchmark/main.cpp
+++ b/benchmark/main.cpp
@@ -961,8 +961,14 @@ static int benchmark( int argc, char *argv[] )
 }
 
 int main(void) {
+    mbedtls_platform_context platform_ctx;
+    if(mbedtls_platform_setup(&platform_ctx)) {
+        return -1;
+    }
+
     int ret = benchmark(0, NULL);
     if (ret != 0) {
         mbedtls_printf("Benchmark failed with error %d\r\n", ret);
     }
+    mbedtls_platform_teardown(&platform_ctx);
 }

--- a/hashing/main.cpp
+++ b/hashing/main.cpp
@@ -152,8 +152,14 @@ static int example(void)
 }
 
 int main() {
+    mbedtls_platform_context platform_ctx;
+    if( mbedtls_platform_setup(&platform_ctx)) {
+        return -1;
+    }
+
     int ret = example();
     if (ret != 0) {
         mbedtls_printf("Example failed with error %d\r\n", ret);
     }
+    mbedtls_platform_teardown(&platform_ctx);
 }

--- a/tls-client/main.cpp
+++ b/tls-client/main.cpp
@@ -412,6 +412,10 @@ protected:
  * The main loop of the HTTPS Hello World test
  */
 int main() {
+    mbedtls_platform_context platform_ctx;
+    if( mbedtls_platform_setup(&platform_ctx)) {
+        return -1;
+    }
     /* The default 9600 bps is too slow to print full TLS debug info and could
      * cause the other party to time out. */
 
@@ -432,10 +436,13 @@ int main() {
 #endif /* DEBUG_LEVEL > 0 */
     if (NULL == network) {
         printf("Connecting to the network failed... See serial output.\n");
+        mbedtls_platform_teardown(&platform_ctx);
         return 1;
     }
 
     HelloHTTPS *hello = new HelloHTTPS(HTTPS_SERVER_NAME, HTTPS_SERVER_PORT, network);
     hello->startTest(HTTPS_PATH);
     delete hello;
+    
+    mbedtls_platform_teardown(&platform_ctx);
 }


### PR DESCRIPTION
Add platform setup and teardown for authcrypt, benchmark, hashing and tls-client examples.
Tested on K64F with GCC_ARM.