### PR TITLE
Updating mbed-os to mbed-os-5.8.4

### DIFF
--- a/authcrypt/mbed-os.lib
+++ b/authcrypt/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c05d72c3c005fbb7e92c3994c32bda45218ae7fe
+https://github.com/ARMmbed/mbed-os/#ae6c7c60f91c89cbf755a2f3c8ec9c66635849fd

--- a/benchmark/mbed-os.lib
+++ b/benchmark/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c05d72c3c005fbb7e92c3994c32bda45218ae7fe
+https://github.com/ARMmbed/mbed-os/#ae6c7c60f91c89cbf755a2f3c8ec9c66635849fd

--- a/hashing/mbed-os.lib
+++ b/hashing/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c05d72c3c005fbb7e92c3994c32bda45218ae7fe
+https://github.com/ARMmbed/mbed-os/#ae6c7c60f91c89cbf755a2f3c8ec9c66635849fd

--- a/tls-client/mbed-os.lib
+++ b/tls-client/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c05d72c3c005fbb7e92c3994c32bda45218ae7fe
+https://github.com/ARMmbed/mbed-os/#ae6c7c60f91c89cbf755a2f3c8ec9c66635849fd


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.8.4 . 