### PR TITLE
Separate server name

### DIFF
--- a/tls-client/HelloHttpsClient.cpp
+++ b/tls-client/HelloHttpsClient.cpp
@@ -81,7 +81,6 @@ HelloHttpsClient::HelloHttpsClient(const char *in_server_name,
      * Please refer to https://github.com/ARMmbed/mbedtls/issues/1200 for more
      * information. */
     platform_ctx(in_platform_ctx)
-
 {
     mbedtls_entropy_init(&entropy);
     mbedtls_ctr_drbg_init(&ctr_drbg);

--- a/tls-client/HelloHttpsClient.cpp
+++ b/tls-client/HelloHttpsClient.cpp
@@ -70,15 +70,18 @@ const char *HelloHttpsClient::HTTP_HELLO_STR = "Hello world!";
 const char *HelloHttpsClient::HTTP_OK_STR = "200 OK";
 
 HelloHttpsClient::HelloHttpsClient(const char *in_server_name,
+                                   const char *in_server_addr,
                                    const uint16_t in_server_port,
                                    mbedtls_platform_context* in_platform_ctx) :
     socket(),
     server_name(in_server_name),
+    server_addr(in_server_addr),
     server_port(in_server_port),
     /* The platform context is passed just in case any crypto calls need it.
      * Please refer to https://github.com/ARMmbed/mbedtls/issues/1200 for more
      * information. */
     platform_ctx(in_platform_ctx)
+
 {
     mbedtls_entropy_init(&entropy);
     mbedtls_ctr_drbg_init(&ctr_drbg);
@@ -114,12 +117,12 @@ int HelloHttpsClient::run()
         return ret;
 
     /* Start a connection to the server */
-    if ((ret = socket.connect(server_name, server_port)) != NSAPI_ERROR_OK) {
+    if ((ret = socket.connect(server_addr, server_port)) != NSAPI_ERROR_OK) {
         mbedtls_printf("socket.connect() returned %d\n", ret);
         return ret;
     }
     mbedtls_printf("Successfully connected to %s at port %u\n",
-                   server_name, server_port);
+                   server_addr, server_port);
 
     /* Start the TLS handshake */
     mbedtls_printf("Starting the TLS handshake...\n");

--- a/tls-client/HelloHttpsClient.h
+++ b/tls-client/HelloHttpsClient.h
@@ -56,11 +56,14 @@ public:
      * Construct an HelloHttpsClient instance
      *
      * \param[in]   in_server_name
+     *              The server host name
+     * \param[in]   in_server_addr
      *              The server domain/IP address
      * \param[in]   in_server_port
      *              The server port
      */
     HelloHttpsClient(const char *in_server_name,
+                     const char *in_server_addr,
                      const uint16_t in_server_port,
                      mbedtls_platform_context* in_platform_ctx);
 
@@ -192,9 +195,14 @@ private:
     TCPSocket socket;
 
     /**
-     * The domain/IP address of the server to contact
+     * The server host name to contact
      */
     const char *server_name;
+
+    /**
+     * The domain/IP address of the server to contact
+     */
+    const char *server_addr;
     /**
      * The port number to use in the connection
      */

--- a/tls-client/main.cpp
+++ b/tls-client/main.cpp
@@ -40,6 +40,7 @@
 
 /* Domain/IP address of the server to contact */
 const char SERVER_NAME[] = "os.mbed.com";
+const char SERVER_ADDR[] = "os.mbed.com";
 
 /* Port used to connect to the server */
 const int SERVER_PORT = 443;
@@ -73,8 +74,9 @@ int main()
 #endif /* MBEDTLS_MAJOR_VERSION */
 
     /* Allocate a HTTPS client */
-    client = new (std::nothrow) HelloHttpsClient(SERVER_NAME, SERVER_PORT,
+    client = new (std::nothrow) HelloHttpsClient(SERVER_NAME, SERVER_ADDR, SERVER_PORT,
                                                  &platform_ctx);
+
     if (client == NULL) {
         mbedtls_printf("Failed to allocate HelloHttpsClient object\n"
                        "\nFAIL\n");


### PR DESCRIPTION
Seperate the server_name into the `server_addr`
which is the address to connect,
and to `server_name` which is the server host_name.
Sometimes these are not the same, and it helps separating them for connecting to other servers