### PR TITLE
Updating mbed-os to mbed-os-5.8.6

### DIFF
--- a/authcrypt/mbed-os.lib
+++ b/authcrypt/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#367dbdf5145f4d6aa3e483c147fe7bda1ce23a36
+https://github.com/ARMmbed/mbed-os/#35fa909641fedcad9bbe0c7300d4ccdf15a2b71a

--- a/benchmark/mbed-os.lib
+++ b/benchmark/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#367dbdf5145f4d6aa3e483c147fe7bda1ce23a36
+https://github.com/ARMmbed/mbed-os/#35fa909641fedcad9bbe0c7300d4ccdf15a2b71a

--- a/hashing/mbed-os.lib
+++ b/hashing/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#367dbdf5145f4d6aa3e483c147fe7bda1ce23a36
+https://github.com/ARMmbed/mbed-os/#35fa909641fedcad9bbe0c7300d4ccdf15a2b71a

--- a/tls-client/mbed-os.lib
+++ b/tls-client/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#367dbdf5145f4d6aa3e483c147fe7bda1ce23a36
+https://github.com/ARMmbed/mbed-os/#35fa909641fedcad9bbe0c7300d4ccdf15a2b71a


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.8.6 . 