### PR TITLE
Updating mbed-os to mbed-os-5.9.2

### DIFF
--- a/authcrypt/mbed-os.lib
+++ b/authcrypt/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#03196b244ee00fc748cd4dbfa83b26f3fc0f376b
+https://github.com/ARMmbed/mbed-os/#62f8b922b420626514fd4690107aff4188469833

--- a/benchmark/mbed-os.lib
+++ b/benchmark/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#03196b244ee00fc748cd4dbfa83b26f3fc0f376b
+https://github.com/ARMmbed/mbed-os/#62f8b922b420626514fd4690107aff4188469833

--- a/hashing/mbed-os.lib
+++ b/hashing/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#03196b244ee00fc748cd4dbfa83b26f3fc0f376b
+https://github.com/ARMmbed/mbed-os/#62f8b922b420626514fd4690107aff4188469833

--- a/tls-client/mbed-os.lib
+++ b/tls-client/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#03196b244ee00fc748cd4dbfa83b26f3fc0f376b
+https://github.com/ARMmbed/mbed-os/#62f8b922b420626514fd4690107aff4188469833


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.9.2 . 