### PR TITLE
use mbedtls_printf instead of printf

### DIFF
--- a/benchmark/main.cpp
+++ b/benchmark/main.cpp
@@ -1019,7 +1019,7 @@ int main(void) {
     int exit_code = MBEDTLS_EXIT_FAILURE;
 
     if((exit_code = mbedtls_platform_setup(&platform_ctx)) != 0) {
-        printf("Platform initialization failed with error %d\r\n", exit_code);
+        mbedtls_printf("Platform initialization failed with error %d\r\n", exit_code);
         return MBEDTLS_EXIT_FAILURE;
     }
 


### PR DESCRIPTION
Change call to `mbedtls_printf()` instead of`printf()`
which was accidently inserted.
Resolves #185 