### PR TITLE
Updating mbed-os to mbed-os-5.9.4

### DIFF
--- a/authcrypt/mbed-os.lib
+++ b/authcrypt/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#50bd61a4a72332baa6b1bac6caccb44dc5423309
+https://github.com/ARMmbed/mbed-os/#485bdeee150e2bc8ed75e27d936060fb63a7a7d1

--- a/benchmark/mbed-os.lib
+++ b/benchmark/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#50bd61a4a72332baa6b1bac6caccb44dc5423309
+https://github.com/ARMmbed/mbed-os/#485bdeee150e2bc8ed75e27d936060fb63a7a7d1

--- a/hashing/mbed-os.lib
+++ b/hashing/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#50bd61a4a72332baa6b1bac6caccb44dc5423309
+https://github.com/ARMmbed/mbed-os/#485bdeee150e2bc8ed75e27d936060fb63a7a7d1

--- a/tls-client/mbed-os.lib
+++ b/tls-client/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#50bd61a4a72332baa6b1bac6caccb44dc5423309
+https://github.com/ARMmbed/mbed-os/#485bdeee150e2bc8ed75e27d936060fb63a7a7d1


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.9.4 . 