### PR TITLE
Revert addition of ecdsa test

### DIFF
--- a/benchmark/main.cpp
+++ b/benchmark/main.cpp
@@ -145,7 +145,7 @@
 /*
  * Uncomment this line to enable ECDSA benchmark.
  */
-#define ENABLE_ECDSA
+//#define ENABLE_ECDSA
 
 /*
  * For heap usage estimates, we need an estimate of the overhead per allocated


### PR DESCRIPTION
Revert the addition of ecdsa test, as it seems that CI still fails.
Resolves #184.