### PR TITLE
Don't use easy-connect, use NetworkInterface::get_default_instance()

### DIFF
--- a/tls-client/easy-connect.lib
+++ b/tls-client/easy-connect.lib
@@ -1,1 +1,0 @@
-https://github.com/ARMmbed/easy-connect/#5b52b5fa56c623d5853c5daf266b34986a0c20cc


### PR DESCRIPTION
After Mbed OS 5.9, there is API to as a default network interface from Mbed OS.

See: https://os.mbed.com/docs/v5.9/reference/configuration-connectivity.html#selecting-the-default-network-interface

During Mbed OS 5.10 all driver should begin to support this, including external drivers.

Also, as some drivers are entering Mbed OS repository, our examples cannot anymore refer to easy-connect which would pull in those exact same drivers. Leads to duplicated code.

This is needed to get this working with 5.10