### PR TITLE
Change mbedtls_platform_context parameter to NULL

### DIFF
--- a/authcrypt/authcrypt.cpp
+++ b/authcrypt/authcrypt.cpp
@@ -39,11 +39,8 @@ const char Authcrypt::message[] = "Some things are better left unread";
 
 const char Authcrypt::metadata[] = "eg sequence number, routing info";
 
-Authcrypt::Authcrypt(mbedtls_platform_context* platform_ctx)
+Authcrypt::Authcrypt()
 {
-    // The platform context can be used by cryptographic calls which require it.
-    // Please refer to https://github.com/ARMmbed/mbedtls/issues/1200 for more information.
-    _platform_ctx = platform_ctx;
     memset(ciphertext, 0, sizeof(ciphertext));
     memset(decrypted, 0, sizeof(decrypted));
 

--- a/authcrypt/authcrypt.h
+++ b/authcrypt/authcrypt.h
@@ -35,7 +35,7 @@ public:
     /**
      * Construct an Authcrypt instance
      */
-    Authcrypt(mbedtls_platform_context* platform_ctx);
+    Authcrypt();
 
     /**
      * Free any allocated resources
@@ -104,11 +104,6 @@ private:
      * The block cipher configuration
      */
     mbedtls_cipher_context_t cipher;
-    
-    /**
-     * The platform context
-     */
-    mbedtls_platform_context* _platform_ctx;
 };
 
 #endif /* _AUTHCRYPT_H_ */

--- a/authcrypt/main.cpp
+++ b/authcrypt/main.cpp
@@ -24,15 +24,14 @@
 #include "mbedtls/platform.h"
 
 int main() {
-    mbedtls_platform_context platform_ctx;
     int exit_code = MBEDTLS_EXIT_FAILURE;
 
-    if((exit_code = mbedtls_platform_setup(&platform_ctx)) != 0) {
+    if((exit_code = mbedtls_platform_setup(NULL)) != 0) {
         printf("Platform initialization failed with error %d\n", exit_code);
         return MBEDTLS_EXIT_FAILURE;
     }
 
-    Authcrypt *authcrypt = new Authcrypt(&platform_ctx);
+    Authcrypt *authcrypt = new Authcrypt();
 
     if ((exit_code = authcrypt->run()) != 0) {
         mbedtls_printf("Example failed with error %d\n", exit_code);
@@ -41,6 +40,6 @@ int main() {
 
     delete authcrypt;
 
-    mbedtls_platform_teardown(&platform_ctx);
+    mbedtls_platform_teardown(NULL);
     return exit_code;
 }

--- a/benchmark/main.cpp
+++ b/benchmark/main.cpp
@@ -343,7 +343,6 @@ exit:
 }
 #endif /* MBEDTLS_SHA512_C */
 
-
 #if defined(MBEDTLS_ARC4_C)
 MBED_NOINLINE static int benchmark_arc4()
 {
@@ -1316,13 +1315,12 @@ exit:
 
 int main()
 {
-    mbedtls_platform_context platform_ctx;
     int exit_code = MBEDTLS_EXIT_SUCCESS;
 
     memset(buf, 0xAA, sizeof(buf));
     memset(tmp, 0xBB, sizeof(tmp));
 
-    if ((exit_code = mbedtls_platform_setup(&platform_ctx)) != 0) {
+    if ((exit_code = mbedtls_platform_setup(NULL)) != 0) {
         mbedtls_printf("Platform initialization failed with error %d\r\n",
                        exit_code);
         return MBEDTLS_EXIT_FAILURE;
@@ -1482,7 +1480,6 @@ int main()
 
     mbedtls_printf("DONE\n");
 
-    mbedtls_platform_teardown(&platform_ctx);
-
+    mbedtls_platform_teardown(NULL);
     return exit_code;
 }

--- a/hashing/main.cpp
+++ b/hashing/main.cpp
@@ -47,13 +47,8 @@ static const char hello_str[] = "Hello, world!";
 static const unsigned char *hello_buffer = (const unsigned char *) hello_str;
 static const size_t hello_len = strlen(hello_str);
 
-static int example(mbedtls_platform_context* ctx)
+static int example()
 {
-    // The call below is used to avoid the "unused parameter" warning.
-    // The context itself can be used by cryptographic calls which require it.
-    // Please refer to https://github.com/ARMmbed/mbedtls/issues/1200 for more information.
-    (void)ctx;
-
     mbedtls_printf("\n\n");
 
     /*
@@ -157,20 +152,19 @@ static int example(mbedtls_platform_context* ctx)
 }
 
 int main() {
-    mbedtls_platform_context platform_ctx;
     int exit_code = MBEDTLS_EXIT_FAILURE;
 
-    if((exit_code = mbedtls_platform_setup(&platform_ctx)) != 0) {
+    if((exit_code = mbedtls_platform_setup(NULL)) != 0) {
         printf("Platform initialization failed with error %d\n", exit_code);
         return MBEDTLS_EXIT_FAILURE;
     }
 
-    exit_code = example(&platform_ctx);
+    exit_code = example();
     if (exit_code != 0) {
         mbedtls_printf("Example failed with error %d\n", exit_code);
         exit_code = MBEDTLS_EXIT_FAILURE;
     }
 
-    mbedtls_platform_teardown(&platform_ctx);
+    mbedtls_platform_teardown(NULL);
     return exit_code;
 }

--- a/tls-client/HelloHttpsClient.cpp
+++ b/tls-client/HelloHttpsClient.cpp
@@ -71,16 +71,11 @@ const char *HelloHttpsClient::HTTP_OK_STR = "200 OK";
 
 HelloHttpsClient::HelloHttpsClient(const char *in_server_name,
                                    const char *in_server_addr,
-                                   const uint16_t in_server_port,
-                                   mbedtls_platform_context* in_platform_ctx) :
+                                   const uint16_t in_server_port) :
     socket(),
     server_name(in_server_name),
     server_addr(in_server_addr),
-    server_port(in_server_port),
-    /* The platform context is passed just in case any crypto calls need it.
-     * Please refer to https://github.com/ARMmbed/mbedtls/issues/1200 for more
-     * information. */
-    platform_ctx(in_platform_ctx)
+    server_port(in_server_port)
 {
     mbedtls_entropy_init(&entropy);
     mbedtls_ctr_drbg_init(&ctr_drbg);

--- a/tls-client/HelloHttpsClient.h
+++ b/tls-client/HelloHttpsClient.h
@@ -25,7 +25,6 @@
 #include "TCPSocket.h"
 
 #include "mbedtls/config.h"
-#include "mbedtls/platform.h"
 #include "mbedtls/ssl.h"
 #include "mbedtls/entropy.h"
 #include "mbedtls/ctr_drbg.h"
@@ -64,8 +63,7 @@ public:
      */
     HelloHttpsClient(const char *in_server_name,
                      const char *in_server_addr,
-                     const uint16_t in_server_port,
-                     mbedtls_platform_context* in_platform_ctx);
+                     const uint16_t in_server_port);
 
     /**
      * Free any allocated resources
@@ -233,8 +231,6 @@ private:
      * The TLS configuration in use
      */
     mbedtls_ssl_config ssl_conf;
-
-    mbedtls_platform_context* platform_ctx;
 };
 
 #endif /* _HELLOHTTPSCLIENT_H_ */

--- a/tls-client/main.cpp
+++ b/tls-client/main.cpp
@@ -50,10 +50,9 @@ const int SERVER_PORT = 443;
  */
 int main()
 {
-    mbedtls_platform_context platform_ctx;
     int exit_code = MBEDTLS_EXIT_FAILURE;
 
-    if((exit_code = mbedtls_platform_setup(&platform_ctx)) != 0) {
+    if((exit_code = mbedtls_platform_setup(NULL)) != 0) {
         printf("Platform initialization failed with error %d\r\n", exit_code);
         return MBEDTLS_EXIT_FAILURE;
     }
@@ -74,13 +73,12 @@ int main()
 #endif /* MBEDTLS_MAJOR_VERSION */
 
     /* Allocate a HTTPS client */
-    client = new (std::nothrow) HelloHttpsClient(SERVER_NAME, SERVER_ADDR, SERVER_PORT,
-                                                 &platform_ctx);
+    client = new (std::nothrow) HelloHttpsClient(SERVER_NAME, SERVER_ADDR, SERVER_PORT);
 
     if (client == NULL) {
         mbedtls_printf("Failed to allocate HelloHttpsClient object\n"
                        "\nFAIL\n");
-        mbedtls_platform_teardown(&platform_ctx);
+        mbedtls_platform_teardown(NULL);
         return exit_code;
     }
 
@@ -94,6 +92,6 @@ int main()
 
     delete client;
 
-    mbedtls_platform_teardown(&platform_ctx);
+    mbedtls_platform_teardown(NULL);
     return exit_code;
 }


### PR DESCRIPTION
`mbedtls_platform_setup()` and `mbedtls_platform_teardown()` now ignore the context parameter, since https://github.com/ARMmbed/mbed-os/pull/7099 was merged. Changing the sent parameter to NULL, to avoid misleading.