### PR TITLE
Add support for the Feature unsupported error

### DIFF
--- a/benchmark/main.cpp
+++ b/benchmark/main.cpp
@@ -157,8 +157,8 @@ do {                                                                        \
     for (i = 1, alarmed = 0, t.attach(alarm, 1.0); !alarmed; i++)           \
     {                                                                       \
         ret = CODE;                                                         \
-        if (ret == MBEDTLS_ERR_AES_FEATURE_UNAVAILABLE) {                   \
-            mbedtls_printf("Feature unavailable\n");                        \
+        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED) {              \
+            mbedtls_printf("Feature unsupported\n");                        \
             break;                                                          \
         } else if (ret != 0) {                                              \
             PRINT_ERROR(ret, #CODE);                                        \
@@ -184,7 +184,11 @@ do {                                                    \
     t.stop();                                           \
     ms = t.read_ms();                                   \
                                                         \
-    if (ret != 0) {                                     \
+    if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)\
+    {                                                   \
+        mbedtls_printf("Feature unsupported\n");        \
+            break;                                      \
+    } else    if (ret != 0) {                           \
         PRINT_ERROR(ret, "Public function");            \
         goto exit;                                      \
     } else {                                            \
@@ -463,9 +467,9 @@ MBED_NOINLINE static int benchmark_aes_cbc()
         memset(tmp, 0, sizeof(tmp));
 
         ret = mbedtls_aes_setkey_enc(&aes, tmp, keysize);
-        if (ret == MBEDTLS_ERR_AES_FEATURE_UNAVAILABLE) {
+        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED) {
             /* Do not consider this as a failure */
-            mbedtls_printf(HEADER_FORMAT "Feature unavailable\n", title);
+            mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
             continue;
         } else if (ret != 0) {
             PRINT_ERROR(ret, "mbedtls_aes_setkey_enc()");
@@ -510,9 +514,9 @@ MBED_NOINLINE static int benchmark_aes_ctr()
         memset(tmp, 0, sizeof(tmp));
 
         ret = mbedtls_aes_setkey_enc(&aes, tmp, keysize);
-        if (ret == MBEDTLS_ERR_AES_FEATURE_UNAVAILABLE) {
+        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED) {
             /* Do not consider this as a failure */
-            mbedtls_printf(HEADER_FORMAT "Feature unavailable\n", title);
+            mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
             continue;
         } else if (ret != 0) {
             PRINT_ERROR(ret, "mbedtls_aes_setkey_enc()");
@@ -555,9 +559,9 @@ MBED_NOINLINE static int benchmark_aes_gcm()
         memset(tmp, 0, sizeof(tmp));
 
         ret = mbedtls_gcm_setkey(&gcm, MBEDTLS_CIPHER_ID_AES, tmp, keysize);
-        if (ret == MBEDTLS_ERR_AES_FEATURE_UNAVAILABLE) {
+        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED) {
             /* Do not consider this as a failure */
-            mbedtls_printf(HEADER_FORMAT "Feature unavailable\n", title);
+            mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
             continue;
         } else if (ret != 0) {
             PRINT_ERROR(ret, "mbedtls_gcm_setkey()");
@@ -601,9 +605,9 @@ MBED_NOINLINE static int benchmark_aes_ccm()
         memset(tmp, 0, sizeof(tmp));
 
         ret = mbedtls_ccm_setkey(&ccm, MBEDTLS_CIPHER_ID_AES, tmp, keysize);
-        if (ret == MBEDTLS_ERR_AES_FEATURE_UNAVAILABLE) {
+        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED) {
             /* Do not consider this as a failure */
-            mbedtls_printf(HEADER_FORMAT "Feature unavailable\n", title);
+            mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
             continue;
         } else if (ret != 0) {
             PRINT_ERROR(ret, "mbedtls_gcm_setkey()");
@@ -695,7 +699,14 @@ MBED_NOINLINE static int benchmark_camellia()
         memset(tmp, 0, sizeof(tmp));
 
         ret = mbedtls_camellia_setkey_enc(&camellia, tmp, keysize);
-        if (ret != 0) {
+        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
+        {
+            /* Do not consider this as a failure */
+            mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
+            ret = 0;
+            continue;
+        }
+        else if (ret != 0) {
             PRINT_ERROR(ret, "mbedtls_camellia_setkey_enc()");
             goto exit;
         }
@@ -742,7 +753,16 @@ MBED_NOINLINE static int benchmark_blowfish()
         memset(buf, 0, sizeof(buf));
         memset(tmp, 0, sizeof(tmp));
 
-        if ((ret = mbedtls_blowfish_setkey(blowfish, tmp, keysize)) != 0) {
+        ret = mbedtls_blowfish_setkey(blowfish, tmp, keysize);
+        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
+        {
+            /* Do not consider this as a failure */
+            mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
+            ret = 0;
+            continue;
+        }
+        else if (ret != 0)
+        {
             PRINT_ERROR(ret, "mbedtls_blowfish_setkey()");
             goto exit;
         }
@@ -910,7 +930,14 @@ MBED_NOINLINE static int benchmark_rsa()
 
         ret = mbedtls_pk_parse_key(&pk, (const unsigned char *)rsa_keys[i],
                                    strlen(rsa_keys[i]) + 1, NULL, 0);
-        if (ret != 0) {
+        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
+        {
+            /* Do not consider this as a failure */
+            mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
+            ret = 0;
+            continue;
+        }
+        else if (ret != 0) {
             PRINT_ERROR(ret, "mbedtls_pk_parse_key()");
             goto exit;
         }
@@ -982,7 +1009,14 @@ MBED_NOINLINE static int benchmark_dhm()
         dhm.len = mbedtls_mpi_size(&dhm.P);
         ret = mbedtls_dhm_make_public(&dhm, (int) dhm.len, buf, dhm.len,
                                       myrand, NULL);
-        if (ret != 0) {
+        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
+        {
+            /* Do not consider this as a failure */
+            mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
+            ret = 0;
+            continue;
+        }
+        else if (ret != 0) {
             PRINT_ERROR(ret, "mbedtls_dhm_make_public()");
             goto exit;
         }
@@ -1051,21 +1085,28 @@ MBED_NOINLINE static int benchmark_ecdsa()
             curve_info++) {
         mbedtls_ecdsa_init(&ecdsa);
 
-        ret = mbedtls_ecdsa_genkey(&ecdsa, curve_info->grp_id, myrand, NULL);
-        if (ret != 0) {
-            PRINT_ERROR(ret, "mbedtls_ecdsa_genkey()");
-            goto exit;
-        }
-
-        ecp_clear_precomputed(&ecdsa.grp);
-
         ret = mbedtls_snprintf(title, sizeof(title), "ECDSA-%s",
-                               curve_info->name);
+                                       curve_info->name);
         if (ret < 0 || static_cast<size_t>(ret) >= sizeof(title)) {
             mbedtls_printf("Failed to compose title string using "
                            "mbedtls_snprintf(): %d\n", ret);
             goto exit;
         }
+
+        ret = mbedtls_ecdsa_genkey(&ecdsa, curve_info->grp_id, myrand, NULL);
+        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
+        {
+            /* Do not consider this as a failure */
+            mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
+            ret = 0;
+            continue;
+        }
+        else if (ret != 0) {
+            PRINT_ERROR(ret, "mbedtls_ecdsa_genkey()");
+            goto exit;
+        }
+
+        ecp_clear_precomputed(&ecdsa.grp);
 
         hash_len = (curve_info->bit_size + 7) / 8;
         BENCHMARK_PUBLIC(title, "sign",
@@ -1084,7 +1125,14 @@ MBED_NOINLINE static int benchmark_ecdsa()
         mbedtls_ecdsa_init(&ecdsa);
 
         ret = mbedtls_ecdsa_genkey(&ecdsa, curve_info->grp_id, myrand, NULL);
-        if (ret != 0) {
+        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
+        {
+            /* Do not consider this as a failure */
+            mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
+            ret = 0;
+            continue;
+        }
+        else if (ret != 0) {
             PRINT_ERROR(ret, "mbedtls_ecdsa_genkey()");
             goto exit;
         }
@@ -1093,7 +1141,14 @@ MBED_NOINLINE static int benchmark_ecdsa()
         ret = mbedtls_ecdsa_write_signature(&ecdsa, MBEDTLS_MD_SHA256, buf,
                                             hash_len, tmp, &sig_len, myrand,
                                             NULL);
-        if (ret != 0) {
+        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
+        {
+            /* Do not consider this as a failure */
+            mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
+            ret = 0;
+            continue;
+        }
+        else if (ret != 0) {
             PRINT_ERROR(ret, "mbedtls_ecdsa_write_signature()");
             goto exit;
         }
@@ -1135,25 +1190,17 @@ MBED_NOINLINE static int benchmark_ecdh()
         mbedtls_ecdh_init(&ecdh);
 
         ret = mbedtls_ecp_group_load(&ecdh.grp, curve_info->grp_id);
-        if (ret != 0) {
+        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
+        {
+            /* Do not consider this as a failure */
+            mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
+            ret = 0;
+            continue;
+        }
+        else if (ret != 0) {
             PRINT_ERROR(ret, "mbedtls_ecp_group_load()");
             goto exit;
         }
-
-        ret = mbedtls_ecdh_make_public(&ecdh, &olen, buf, sizeof(buf),
-                                       myrand, NULL);
-        if (ret != 0) {
-            PRINT_ERROR(ret, "mbedtls_ecdh_make_public()");
-            goto exit;
-        }
-
-        ret = mbedtls_ecp_copy(&ecdh.Qp, &ecdh.Q);
-        if (ret != 0) {
-            PRINT_ERROR(ret, "mbedtls_ecp_copy()");
-            goto exit;
-        }
-
-        ecp_clear_precomputed(&ecdh.grp);
 
         ret = mbedtls_snprintf(title, sizeof(title), "ECDHE-%s",
                                curve_info->name);
@@ -1162,6 +1209,37 @@ MBED_NOINLINE static int benchmark_ecdh()
                            "mbedtls_snprintf(): %d\n", ret);
             goto exit;
         }
+
+        ret = mbedtls_ecdh_make_public(&ecdh, &olen, buf, sizeof(buf),
+                                       myrand, NULL);
+        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
+        {
+            /* Do not consider this as a failure */
+            mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
+            ret = 0;
+            continue;
+        }
+        else if (ret != 0) {
+            PRINT_ERROR(ret, "mbedtls_ecdh_make_public()");
+            goto exit;
+        }
+
+        ret = mbedtls_ecp_copy(&ecdh.Qp, &ecdh.Q);
+        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
+        {
+            /* Do not consider this as a failure */
+            mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
+            ret = 0;
+            continue;
+        }
+        else if (ret != 0) {
+            PRINT_ERROR(ret, "mbedtls_ecp_copy()");
+            goto exit;
+        }
+
+        ecp_clear_precomputed(&ecdh.grp);
+
+
 
         /*
          * Benchmarking this requires two function calls that can fail. We
@@ -1188,40 +1266,69 @@ MBED_NOINLINE static int benchmark_ecdh()
         mbedtls_ecdh_init(&ecdh);
 
         ret = mbedtls_ecp_group_load(&ecdh.grp, curve_info->grp_id);
-        if (ret != 0) {
+        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
+        {
+            /* Do not consider this as a failure */
+            mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
+            ret = 0;
+            continue;
+        }
+        else if (ret != 0) {
             PRINT_ERROR(ret, "mbedtls_ecp_group_load()");
+            goto exit;
+        }
+
+        ret = mbedtls_snprintf(title, sizeof(title), "ECDH-%s",
+                                       curve_info->name);
+        if (ret < 0 || static_cast<size_t>(ret) >= sizeof(title)) {
+            mbedtls_printf("Failed to compose title string using "
+                           "mbedtls_snprintf(): %d\n", ret);
             goto exit;
         }
 
         ret = mbedtls_ecdh_make_public(&ecdh, &olen, buf, sizeof(buf), myrand,
                                        NULL);
-        if (ret != 0) {
+        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
+        {
+            /* Do not consider this as a failure */
+            mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
+            ret = 0;
+            continue;
+        }
+        else if (ret != 0) {
             PRINT_ERROR(ret, "mbedtls_ecdh_make_public()");
             goto exit;
         }
 
         ret = mbedtls_ecp_copy(&ecdh.Qp, &ecdh.Q);
-        if (ret != 0) {
+        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
+        {
+            /* Do not consider this as a failure */
+            mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
+            ret = 0;
+            continue;
+        }
+        else if (ret != 0) {
             PRINT_ERROR(ret, "mbedtls_ecp_copy()");
             goto exit;
         }
 
         ret = mbedtls_ecdh_make_public(&ecdh, &olen, buf, sizeof(buf), myrand,
                                        NULL);
-        if (ret != 0) {
+        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
+        {
+            /* Do not consider this as a failure */
+            mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
+            ret = 0;
+            continue;
+        }
+        else if (ret != 0) {
             PRINT_ERROR(ret, "mbedtls_ecdh_make_public()");
             goto exit;
         }
 
         ecp_clear_precomputed(&ecdh.grp);
 
-        ret = mbedtls_snprintf(title, sizeof(title), "ECDH-%s",
-                               curve_info->name);
-        if (ret < 0 || static_cast<size_t>(ret) >= sizeof(title)) {
-            mbedtls_printf("Failed to compose title string using "
-                           "mbedtls_snprintf(): %d\n", ret);
-            goto exit;
-        }
         BENCHMARK_PUBLIC(title, "handshake",
                          ret = mbedtls_ecdh_calc_secret(&ecdh, &olen, buf,
                                  sizeof(buf), myrand,
@@ -1246,15 +1353,36 @@ MBED_NOINLINE static int benchmark_ecdh_curve22519()
     mbedtls_ecdh_init(&ecdh);
     mbedtls_mpi_init(&z);
 
+    ret = mbedtls_snprintf(title, sizeof(title), "ECDHE-Curve25519");
+     if (ret < 0 || static_cast<size_t>(ret) >= sizeof(title)) {
+         mbedtls_printf("Failed to compose title string using "
+                        "mbedtls_snprintf(): %d\n", ret);
+         goto exit;
+     }
+
     ret = mbedtls_ecp_group_load(&ecdh.grp, MBEDTLS_ECP_DP_CURVE25519);
-    if (ret != 0) {
+    if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
+    {
+        /* Do not consider this as a failure */
+        mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
+        ret = 0;
+        goto exit;
+    }
+    else if (ret != 0) {
         PRINT_ERROR(ret, "mbedtls_ecp_group_load()");
         goto exit;
     }
 
     ret = mbedtls_ecdh_gen_public(&ecdh.grp, &ecdh.d, &ecdh.Qp, myrand,
                                   NULL);
-    if (ret != 0) {
+    if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
+    {
+        /* Do not consider this as a failure */
+        mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
+        ret = 0;
+        goto exit;
+    }
+    else if (ret != 0) {
         PRINT_ERROR(ret, "mbedtls_ecdh_gen_public()");
         goto exit;
     }
@@ -1264,7 +1392,7 @@ MBED_NOINLINE static int benchmark_ecdh_curve22519()
      * add a check in between them to check for any errors. In normal
      * operation, the overhead of this check is negligible
      */
-    BENCHMARK_PUBLIC("ECDHE-Curve25519", "handshake",
+    BENCHMARK_PUBLIC(title, "handshake",
                      ret = mbedtls_ecdh_gen_public(&ecdh.grp, &ecdh.d,
                              &ecdh.Q, myrand, NULL);
                      if (ret != 0) {
@@ -1281,25 +1409,53 @@ MBED_NOINLINE static int benchmark_ecdh_curve22519()
     mbedtls_ecdh_init(&ecdh);
     mbedtls_mpi_init(&z);
 
+    ret = mbedtls_snprintf(title, sizeof(title), "ECDH-Curve25519");
+         if (ret < 0 || static_cast<size_t>(ret) >= sizeof(title)) {
+             mbedtls_printf("Failed to compose title string using "
+                            "mbedtls_snprintf(): %d\n", ret);
+             goto exit;
+         }
     ret = mbedtls_ecp_group_load(&ecdh.grp, MBEDTLS_ECP_DP_CURVE25519);
-    if (ret != 0) {
+    if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
+    {
+        /* Do not consider this as a failure */
+        mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
+        ret = 0;
+        goto exit;
+    }
+    else if (ret != 0) {
         PRINT_ERROR(ret, "mbedtls_ecp_group_load()");
         goto exit;
     }
 
     ret = mbedtls_ecdh_gen_public(&ecdh.grp, &ecdh.d, &ecdh.Qp, myrand, NULL);
-    if (ret != 0) {
+    if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
+    {
+        /* Do not consider this as a failure */
+        mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
+        ret = 0;
+        goto exit;
+    }
+    else if (ret != 0) {
         PRINT_ERROR(ret, "mbedtls_ecdh_gen_public()");
         goto exit;
     }
 
     ret = mbedtls_ecdh_gen_public(&ecdh.grp, &ecdh.d, &ecdh.Q, myrand, NULL);
+    if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
+    {
+        /* Do not consider this as a failure */
+        mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
+        ret = 0;
+        goto exit;
+    }
+    else
     if (ret != 0) {
         PRINT_ERROR(ret, "mbedtls_ecdh_gen_public()");
         goto exit;
     }
 
-    BENCHMARK_PUBLIC("ECDH-Curve25519", "handshake",
+    BENCHMARK_PUBLIC(title, "handshake",
                      ret = mbedtls_ecdh_compute_shared(&ecdh.grp, &z,
                              &ecdh.Qp, &ecdh.d,
                              myrand, NULL));

--- a/benchmark/main.cpp
+++ b/benchmark/main.cpp
@@ -154,8 +154,7 @@ do {                                                                        \
     mbedtls_printf(HEADER_FORMAT, TITLE);                                   \
     fflush(stdout);                                                         \
                                                                             \
-    for (i = 1, alarmed = 0, t.attach(alarm, 1.0); !alarmed; i++)           \
-    {                                                                       \
+    for (i = 1, alarmed = 0, t.attach(alarm, 1.0); !alarmed; i++) {         \
         ret = CODE;                                                         \
         if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED) {              \
             mbedtls_printf("Feature unsupported\n");                        \
@@ -171,34 +170,29 @@ do {                                                                        \
     }                                                                       \
 } while(0)
 
-#define BENCHMARK_PUBLIC(TITLE, TYPE, CODE)             \
-do {                                                    \
-    unsigned long ms;                                   \
-    Timer t;                                            \
-                                                        \
-    mbedtls_printf(HEADER_FORMAT, TITLE);               \
-    fflush(stdout);                                     \
-                                                        \
-    t.start();                                          \
-    CODE;                                               \
-    t.stop();                                           \
-    ms = t.read_ms();                                   \
-                                                        \
-    if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)\
-    {                                                   \
-        mbedtls_printf("Feature unsupported\n");        \
-            break;                                      \
-    }                                                   \
-    else if (ret != 0)                                  \
-    {                                                   \
-        PRINT_ERROR(ret, "Public function");            \
-        goto exit;                                      \
-    }                                                   \
-    else                                                \
-    {                                                   \
-        mbedtls_printf("%6lu ms/" TYPE, ms);            \
-        mbedtls_printf("\n");                           \
-    }                                                   \
+#define BENCHMARK_PUBLIC(TITLE, TYPE, CODE)               \
+do {                                                      \
+    unsigned long ms;                                     \
+    Timer t;                                              \
+                                                          \
+    mbedtls_printf(HEADER_FORMAT, TITLE);                 \
+    fflush(stdout);                                       \
+                                                          \
+    t.start();                                            \
+    CODE;                                                 \
+    t.stop();                                             \
+    ms = t.read_ms();                                     \
+                                                          \
+    if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED) {\
+        mbedtls_printf("Feature unsupported\n");          \
+            break;                                        \
+    } else if (ret != 0) {                                \
+        PRINT_ERROR(ret, "Public function");              \
+        goto exit;                                        \
+    } else {                                              \
+        mbedtls_printf("%6lu ms/" TYPE, ms);              \
+        mbedtls_printf("\n");                             \
+    }                                                     \
 } while(0)
 
 /* Clear some memory that was used to prepare the context */
@@ -703,14 +697,12 @@ MBED_NOINLINE static int benchmark_camellia()
         memset(tmp, 0, sizeof(tmp));
 
         ret = mbedtls_camellia_setkey_enc(&camellia, tmp, keysize);
-        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
-        {
+        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED) {
             /* Do not consider this as a failure */
             mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
             ret = 0;
             continue;
-        }
-        else if (ret != 0) {
+        } else if (ret != 0) {
             PRINT_ERROR(ret, "mbedtls_camellia_setkey_enc()");
             goto exit;
         }
@@ -758,15 +750,12 @@ MBED_NOINLINE static int benchmark_blowfish()
         memset(tmp, 0, sizeof(tmp));
 
         ret = mbedtls_blowfish_setkey(blowfish, tmp, keysize);
-        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
-        {
+        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED) {
             /* Do not consider this as a failure */
             mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
             ret = 0;
             continue;
-        }
-        else if (ret != 0)
-        {
+        } else if (ret != 0) {
             PRINT_ERROR(ret, "mbedtls_blowfish_setkey()");
             goto exit;
         }
@@ -934,14 +923,12 @@ MBED_NOINLINE static int benchmark_rsa()
 
         ret = mbedtls_pk_parse_key(&pk, (const unsigned char *)rsa_keys[i],
                                    strlen(rsa_keys[i]) + 1, NULL, 0);
-        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
-        {
+        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED) {
             /* Do not consider this as a failure */
             mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
             ret = 0;
             continue;
-        }
-        else if (ret != 0) {
+        } else if (ret != 0) {
             PRINT_ERROR(ret, "mbedtls_pk_parse_key()");
             goto exit;
         }
@@ -1013,14 +1000,12 @@ MBED_NOINLINE static int benchmark_dhm()
         dhm.len = mbedtls_mpi_size(&dhm.P);
         ret = mbedtls_dhm_make_public(&dhm, (int) dhm.len, buf, dhm.len,
                                       myrand, NULL);
-        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
-        {
+        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED) {
             /* Do not consider this as a failure */
             mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
             ret = 0;
             continue;
-        }
-        else if (ret != 0) {
+        } else if (ret != 0) {
             PRINT_ERROR(ret, "mbedtls_dhm_make_public()");
             goto exit;
         }
@@ -1098,14 +1083,12 @@ MBED_NOINLINE static int benchmark_ecdsa()
         }
 
         ret = mbedtls_ecdsa_genkey(&ecdsa, curve_info->grp_id, myrand, NULL);
-        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
-        {
+        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED) {
             /* Do not consider this as a failure */
             mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
             ret = 0;
             continue;
-        }
-        else if (ret != 0) {
+        } else if (ret != 0) {
             PRINT_ERROR(ret, "mbedtls_ecdsa_genkey()");
             goto exit;
         }
@@ -1129,14 +1112,12 @@ MBED_NOINLINE static int benchmark_ecdsa()
         mbedtls_ecdsa_init(&ecdsa);
 
         ret = mbedtls_ecdsa_genkey(&ecdsa, curve_info->grp_id, myrand, NULL);
-        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
-        {
+        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED) {
             /* Do not consider this as a failure */
             mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
             ret = 0;
             continue;
-        }
-        else if (ret != 0) {
+        } else if (ret != 0) {
             PRINT_ERROR(ret, "mbedtls_ecdsa_genkey()");
             goto exit;
         }
@@ -1145,14 +1126,12 @@ MBED_NOINLINE static int benchmark_ecdsa()
         ret = mbedtls_ecdsa_write_signature(&ecdsa, MBEDTLS_MD_SHA256, buf,
                                             hash_len, tmp, &sig_len, myrand,
                                             NULL);
-        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
-        {
+        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED) {
             /* Do not consider this as a failure */
             mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
             ret = 0;
             continue;
-        }
-        else if (ret != 0) {
+        } else if (ret != 0) {
             PRINT_ERROR(ret, "mbedtls_ecdsa_write_signature()");
             goto exit;
         }
@@ -1194,14 +1173,12 @@ MBED_NOINLINE static int benchmark_ecdh()
         mbedtls_ecdh_init(&ecdh);
 
         ret = mbedtls_ecp_group_load(&ecdh.grp, curve_info->grp_id);
-        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
-        {
+        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED) {
             /* Do not consider this as a failure */
             mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
             ret = 0;
             continue;
-        }
-        else if (ret != 0) {
+        } else if (ret != 0) {
             PRINT_ERROR(ret, "mbedtls_ecp_group_load()");
             goto exit;
         }
@@ -1216,27 +1193,23 @@ MBED_NOINLINE static int benchmark_ecdh()
 
         ret = mbedtls_ecdh_make_public(&ecdh, &olen, buf, sizeof(buf),
                                        myrand, NULL);
-        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
-        {
+        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED) {
             /* Do not consider this as a failure */
             mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
             ret = 0;
             continue;
-        }
-        else if (ret != 0) {
+        } else if (ret != 0) {
             PRINT_ERROR(ret, "mbedtls_ecdh_make_public()");
             goto exit;
         }
 
         ret = mbedtls_ecp_copy(&ecdh.Qp, &ecdh.Q);
-        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
-        {
+        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED) {
             /* Do not consider this as a failure */
             mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
             ret = 0;
             continue;
-        }
-        else if (ret != 0) {
+        } else if (ret != 0) {
             PRINT_ERROR(ret, "mbedtls_ecp_copy()");
             goto exit;
         }
@@ -1268,14 +1241,12 @@ MBED_NOINLINE static int benchmark_ecdh()
         mbedtls_ecdh_init(&ecdh);
 
         ret = mbedtls_ecp_group_load(&ecdh.grp, curve_info->grp_id);
-        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
-        {
+        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED) {
             /* Do not consider this as a failure */
             mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
             ret = 0;
             continue;
-        }
-        else if (ret != 0) {
+        } else if (ret != 0) {
             PRINT_ERROR(ret, "mbedtls_ecp_group_load()");
             goto exit;
         }
@@ -1290,41 +1261,35 @@ MBED_NOINLINE static int benchmark_ecdh()
 
         ret = mbedtls_ecdh_make_public(&ecdh, &olen, buf, sizeof(buf), myrand,
                                        NULL);
-        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
-        {
+        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED) {
             /* Do not consider this as a failure */
             mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
             ret = 0;
             continue;
-        }
-        else if (ret != 0) {
+        } else if (ret != 0) {
             PRINT_ERROR(ret, "mbedtls_ecdh_make_public()");
             goto exit;
         }
 
         ret = mbedtls_ecp_copy(&ecdh.Qp, &ecdh.Q);
-        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
-        {
+        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED) {
             /* Do not consider this as a failure */
             mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
             ret = 0;
             continue;
-        }
-        else if (ret != 0) {
+        } else if (ret != 0) {
             PRINT_ERROR(ret, "mbedtls_ecp_copy()");
             goto exit;
         }
 
         ret = mbedtls_ecdh_make_public(&ecdh, &olen, buf, sizeof(buf), myrand,
                                        NULL);
-        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
-        {
+        if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED) {
             /* Do not consider this as a failure */
             mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
             ret = 0;
             continue;
-        }
-        else if (ret != 0) {
+        } else if (ret != 0) {
             PRINT_ERROR(ret, "mbedtls_ecdh_make_public()");
             goto exit;
         }
@@ -1356,36 +1321,31 @@ MBED_NOINLINE static int benchmark_ecdh_curve22519()
     mbedtls_mpi_init(&z);
 
     ret = mbedtls_snprintf(title, sizeof(title), "ECDHE-Curve25519");
-    if (ret < 0 || static_cast<size_t>(ret) >= sizeof(title))
-    {
+    if (ret < 0 || static_cast<size_t>(ret) >= sizeof(title)) {
         mbedtls_printf("Failed to compose title string using "
                         "mbedtls_snprintf(): %d\n", ret);
          goto exit;
      }
 
     ret = mbedtls_ecp_group_load(&ecdh.grp, MBEDTLS_ECP_DP_CURVE25519);
-    if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
-    {
+    if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED) {
         /* Do not consider this as a failure */
         mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
         ret = 0;
         goto exit;
-    }
-    else if (ret != 0) {
+    } else if (ret != 0) {
         PRINT_ERROR(ret, "mbedtls_ecp_group_load()");
         goto exit;
     }
 
     ret = mbedtls_ecdh_gen_public(&ecdh.grp, &ecdh.d, &ecdh.Qp, myrand,
                                   NULL);
-    if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
-    {
+    if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED) {
         /* Do not consider this as a failure */
         mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
         ret = 0;
         goto exit;
-    }
-    else if (ret != 0) {
+    } else if (ret != 0) {
         PRINT_ERROR(ret, "mbedtls_ecdh_gen_public()");
         goto exit;
     }
@@ -1419,41 +1379,34 @@ MBED_NOINLINE static int benchmark_ecdh_curve22519()
              goto exit;
          }
     ret = mbedtls_ecp_group_load(&ecdh.grp, MBEDTLS_ECP_DP_CURVE25519);
-    if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
-    {
+    if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED) {
         /* Do not consider this as a failure */
         mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
         ret = 0;
         goto exit;
-    }
-    else if (ret != 0) {
+    } else if (ret != 0) {
         PRINT_ERROR(ret, "mbedtls_ecp_group_load()");
         goto exit;
     }
 
     ret = mbedtls_ecdh_gen_public(&ecdh.grp, &ecdh.d, &ecdh.Qp, myrand, NULL);
-    if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
-    {
+    if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED) {
         /* Do not consider this as a failure */
         mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
         ret = 0;
         goto exit;
-    }
-    else if (ret != 0) {
+    } else if (ret != 0) {
         PRINT_ERROR(ret, "mbedtls_ecdh_gen_public()");
         goto exit;
     }
 
     ret = mbedtls_ecdh_gen_public(&ecdh.grp, &ecdh.d, &ecdh.Q, myrand, NULL);
-    if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED)
-    {
+    if (ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED) {
         /* Do not consider this as a failure */
         mbedtls_printf(HEADER_FORMAT "Feature unsupported\n", title);
         ret = 0;
         goto exit;
-    }
-    else
-    if (ret != 0) {
+    } else if (ret != 0) {
         PRINT_ERROR(ret, "mbedtls_ecdh_gen_public()");
         goto exit;
     }

--- a/benchmark/main.cpp
+++ b/benchmark/main.cpp
@@ -188,10 +188,14 @@ do {                                                    \
     {                                                   \
         mbedtls_printf("Feature unsupported\n");        \
             break;                                      \
-    } else    if (ret != 0) {                           \
+    }                                                   \
+    else if (ret != 0)                                  \
+    {                                                   \
         PRINT_ERROR(ret, "Public function");            \
         goto exit;                                      \
-    } else {                                            \
+    }                                                   \
+    else                                                \
+    {                                                   \
         mbedtls_printf("%6lu ms/" TYPE, ms);            \
         mbedtls_printf("\n");                           \
     }                                                   \
@@ -1086,7 +1090,7 @@ MBED_NOINLINE static int benchmark_ecdsa()
         mbedtls_ecdsa_init(&ecdsa);
 
         ret = mbedtls_snprintf(title, sizeof(title), "ECDSA-%s",
-                                       curve_info->name);
+                               curve_info->name);
         if (ret < 0 || static_cast<size_t>(ret) >= sizeof(title)) {
             mbedtls_printf("Failed to compose title string using "
                            "mbedtls_snprintf(): %d\n", ret);
@@ -1239,8 +1243,6 @@ MBED_NOINLINE static int benchmark_ecdh()
 
         ecp_clear_precomputed(&ecdh.grp);
 
-
-
         /*
          * Benchmarking this requires two function calls that can fail. We
          * add a check in between them to check for any errors. In normal
@@ -1354,8 +1356,9 @@ MBED_NOINLINE static int benchmark_ecdh_curve22519()
     mbedtls_mpi_init(&z);
 
     ret = mbedtls_snprintf(title, sizeof(title), "ECDHE-Curve25519");
-     if (ret < 0 || static_cast<size_t>(ret) >= sizeof(title)) {
-         mbedtls_printf("Failed to compose title string using "
+    if (ret < 0 || static_cast<size_t>(ret) >= sizeof(title))
+    {
+        mbedtls_printf("Failed to compose title string using "
                         "mbedtls_snprintf(): %d\n", ret);
          goto exit;
      }

--- a/tests/benchmark.log
+++ b/tests/benchmark.log
@@ -1,51 +1,51 @@
-\s+MD4\s*:\s*\d+ KB/s
-\s+MD5\s*:\s*\d+ KB/s
-\s+RIPEMD160\s*:\s*\d+ KB/s
-\s+SHA-1\s*:\s*\d+ KB/s
-\s+SHA-256\s*:\s*\d+ KB/s
-\s+SHA-512\s*:\s*\d+ KB/s
-\s+ARC4\s*:\s*\d+ KB/s
-\s+3DES\s*:\s*\d+ KB/s
-\s+DES\s*:\s*\d+ KB/s
-\s+3DES-CMAC\s*:\s*\d+ KB/s
-\s+AES-CBC-128\s*:\s*(\d+ KB/s|Feature unavailable)
-\s+AES-CBC-192\s*:\s*(\d+ KB/s|Feature unavailable)
-\s+AES-CBC-256\s*:\s*(\d+ KB/s|Feature unavailable)
-\s+AES-CTR-128\s*:\s*(\d+ KB/s|Feature unavailable)
-\s+AES-CTR-192\s*:\s*(\d+ KB/s|Feature unavailable)
-\s+AES-CTR-256\s*:\s*(\d+ KB/s|Feature unavailable)
-\s+AES-GCM-128\s*:\s*(\d+ KB/s|Feature unavailable)
-\s+AES-GCM-192\s*:\s*(\d+ KB/s|Feature unavailable)
-\s+AES-GCM-256\s*:\s*(\d+ KB/s|Feature unavailable)
-\s+AES-CCM-128\s*:\s*(\d+ KB/s|Feature unavailable)
-\s+AES-CCM-192\s*:\s*(\d+ KB/s|Feature unavailable)
-\s+AES-CCM-256\s*:\s*(\d+ KB/s|Feature unavailable)
-\s+AES-CMAC-128\s*:\s*(\d+ KB/s|Feature unavailable)
-\s+AES-CMAC-192\s*:\s*(\d+ KB/s|Feature unavailable)
-\s+AES-CMAC-256\s*:\s*(\d+ KB/s|Feature unavailable)
-\s+AES-CMAC-PRF-128\s*:\s*(\d+ KB/s|Feature unavailable)
-\s+CAMELLIA-CBC-128\s*:\s*\d+ KB/s
-\s+CAMELLIA-CBC-192\s*:\s*\d+ KB/s
-\s+CAMELLIA-CBC-256\s*:\s*\d+ KB/s
-\s+BLOWFISH-CBC-128\s*:\s*\d+ KB/s
-\s+BLOWFISH-CBC-192\s*:\s*\d+ KB/s
-\s+BLOWFISH-CBC-256\s*:\s*\d+ KB/s
-\s+CTR_DRBG \(NOPR\)\s*:\s*(\d+ KB/s|Feature unavailable)
-\s+CTR_DRBG \(PR\)\s*:\s*(\d+ KB/s|Feature unavailable)
-\s+HMAC_DRBG SHA-1 \(NOPR\)\s*:\s*\d+ KB/s
-\s+HMAC_DRBG SHA-1 \(PR\)\s*:\s*\d+ KB/s
-\s+HMAC_DRBG SHA-256 \(NOPR\)\s*:\s*\d+ KB/s
-\s+HMAC_DRBG SHA-256 \(PR\)\s*:\s*\d+ KB/s
-\s+RSA-2048\s*:\s*\d+ ms/ public
-\s+RSA-2048\s*:\s*\d+ ms/private
-\s+ECDSA-secp384r1\s*:\s*\d+ ms/sign
-\s+ECDSA-secp256r1\s*:\s*\d+ ms/sign
-\s+ECDSA-secp384r1\s*:\s*\d+ ms/verify
-\s+ECDSA-secp256r1\s*:\s*\d+ ms/verify
-\s+ECDHE-secp384r1\s*:\s*\d+ ms/handshake
-\s+ECDHE-secp256r1\s*:\s*\d+ ms/handshake
-\s+ECDH-secp384r1\s*:\s*\d+ ms/handshake
-\s+ECDH-secp256r1\s*:\s*\d+ ms/handshake
-\s+ECDHE-Curve25519\s*:\s*\d+ ms/handshake
-\s+ECDH-Curve25519\s*:\s*\d+ ms/handshake
+\s+MD4\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+MD5\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+RIPEMD160\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+SHA-1\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+SHA-256\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+SHA-512\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+ARC4\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+3DES\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+DES\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+3DES-CMAC\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+AES-CBC-128\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+AES-CBC-192\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+AES-CBC-256\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+AES-CTR-128\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+AES-CTR-192\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+AES-CTR-256\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+AES-GCM-128\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+AES-GCM-192\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+AES-GCM-256\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+AES-CCM-128\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+AES-CCM-192\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+AES-CCM-256\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+AES-CMAC-128\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+AES-CMAC-192\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+AES-CMAC-256\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+AES-CMAC-PRF-128\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+CAMELLIA-CBC-128\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+CAMELLIA-CBC-192\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+CAMELLIA-CBC-256\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+BLOWFISH-CBC-128\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+BLOWFISH-CBC-192\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+BLOWFISH-CBC-256\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+CTR_DRBG \(NOPR\)\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+CTR_DRBG \(PR\)\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+HMAC_DRBG SHA-1 \(NOPR\)\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+HMAC_DRBG SHA-1 \(PR\)\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+HMAC_DRBG SHA-256 \(NOPR\)\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+HMAC_DRBG SHA-256 \(PR\)\s*:\s*(\d+ KB/s|Feature unsupported)
+\s+RSA-2048\s*:\s*(\d+ ms/ public|Feature unsupported)
+\s+RSA-2048\s*:\s*(\d+ ms/private|Feature unsupported)
+\s+ECDSA-secp384r1\s*:\s*(\d+ ms/sign|Feature unsupported)
+\s+ECDSA-secp256r1\s*:\s*(\d+ ms/sign|Feature unsupported)
+\s+ECDSA-secp384r1\s*:\s*(\d+ ms/verify|Feature unsupported)
+\s+ECDSA-secp256r1\s*:\s*(\d+ ms/verify|Feature unsupported)
+\s+ECDHE-secp384r1\s*:\s*(\d+ ms/handshake|Feature unsupported)
+\s+ECDHE-secp256r1\s*:\s*(\d+ ms/handshake|Feature unsupported)
+\s+ECDH-secp384r1\s*:\s*(\d+ ms/handshake|Feature unsupported)
+\s+ECDH-secp256r1\s*:\s*(\d+ ms/handshake|Feature unsupported)
+\s+ECDHE-Curve25519\s*:\s*(\d+ ms/handshake|Feature unsupported)
+\s+ECDH-Curve25519\s*:\s*(\d+ ms/handshake|Feature unsupported)
 DONE


### PR DESCRIPTION
Add support for `MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED`.
If the underlying platform does not support the current feature,
skip the test, instead of failing.

Dependent on https://github.com/ARMmbed/mbed-os/pull/8643 and https://github.com/ARMmbed/mbedtls/pull/2054 to be merged