### PR TITLE
Remove non-default, memory-heavy tests from the benchmark application

### DIFF
--- a/benchmark/main.cpp
+++ b/benchmark/main.cpp
@@ -903,7 +903,6 @@ MBED_NOINLINE static int benchmark_rsa()
     mbedtls_rsa_context *rsa;
     const char *rsa_keys[] = {
         RSA_PRIVATE_KEY_2048,
-        RSA_PRIVATE_KEY_4096,
     };
     size_t i;
 

--- a/benchmark/mbedtls_config.h
+++ b/benchmark/mbedtls_config.h
@@ -89,10 +89,6 @@
 #define MBEDTLS_RSA_C
 #endif
 
-#if !defined(MBEDTLS_DHM_C)
-#define MBEDTLS_DHM_C
-#endif
-
 #if !defined(MBEDTLS_ECDSA_C)
 #define MBEDTLS_ECDSA_C
 #endif

--- a/tests/benchmark.log
+++ b/tests/benchmark.log
@@ -38,12 +38,6 @@
 \s+HMAC_DRBG SHA-256 \(PR\)\s*:\s*\d+ KB/s
 \s+RSA-2048\s*:\s*\d+ ms/ public
 \s+RSA-2048\s*:\s*\d+ ms/private
-\s+RSA-4096\s*:\s*\d+ ms/ public
-\s+RSA-4096\s*:\s*\d+ ms/private
-\s+DHE-2048\s*:\s*\d+ ms/handshake
-\s+DH-2048\s*:\s*\d+ ms/handshake
-\s+DHE-3072\s*:\s*\d+ ms/handshake
-\s+DH-3072\s*:\s*\d+ ms/handshake
 \s+ECDSA-secp384r1\s*:\s*\d+ ms/sign
 \s+ECDSA-secp256r1\s*:\s*\d+ ms/sign
 \s+ECDSA-secp384r1\s*:\s*\d+ ms/verify


### PR DESCRIPTION
This PR removes memory-heavy tests from the benchmark application. They are not used by default and they don't work for all the tested devices due to the memory restrictions (at least ones implied by the build configurations).

Fixes (works around until we have resolved the memory configuration issues) #138 

edit:
It apparently also fixes (works around...) #208 and #210.