### PR TITLE
Undefine MBEDTLS_MPI_MAX_SIZE

### DIFF
--- a/tls-client/mbedtls_entropy_config.h
+++ b/tls-client/mbedtls_entropy_config.h
@@ -33,6 +33,7 @@
  *  Set this value higher to enable handling larger keys, but be aware that this
  *  will increase the stack usage.
  */
+#undef MBEDTLS_MPI_MAX_SIZE
 #define MBEDTLS_MPI_MAX_SIZE        256
 
 #define MBEDTLS_MPI_WINDOW_SIZE     1


### PR DESCRIPTION
Undefine `MBEDTLS_MPI_MAX_SIZE` in case it is already defined
in the configuration file.
This should avoid compilation warnings  and unintended behaviour, once https://github.com/ARMmbed/mbed-os/pull/8936 will be merged