### PR TITLE
Set default network driver on Ublox target to ethernet

### DIFF
--- a/tls-client/mbed_app.json
+++ b/tls-client/mbed_app.json
@@ -31,7 +31,7 @@
              "platform.stdio-convert-newlines": true
         },
         "UBLOX_EVK_ODIN_W2": {
-            "target.device_has_remove": ["EMAC"]
+            "target.network-default-interface-type" : "ETHERNET"
         }
     }
 }


### PR DESCRIPTION
The tls-client example needs updating for the UBLOX_EVK_ODIN_W2 platform to correctly set the default network interface to be ethernet.

The previous fix was discussed in #26, however the suggested fix in https://github.com/ARMmbed/mbed-os-example-tls/issues/26#issuecomment-275036468 now shows the change we wish to make here.