### PR TITLE
Allow the use of PSA Crypto in TLS client example

### DIFF
--- a/tls-client/main.cpp
+++ b/tls-client/main.cpp
@@ -35,6 +35,9 @@
 #include "mbed.h"
 
 #include "mbedtls/platform.h"
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+#include "psa/crypto.h"
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #include "HelloHttpsClient.h"
 
@@ -51,6 +54,24 @@ const int SERVER_PORT = 443;
 int main()
 {
     int exit_code = MBEDTLS_EXIT_FAILURE;
+
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    /*
+     * Initialize underlying PSA Crypto implementation.
+     * Even if the HTTPS client doesn't make use of
+     * PSA-specific API, for example for setting opaque PSKs
+     * or opaque private keys, Mbed TLS will use PSA
+     * for public and symmetric key operations as well as
+     * hashing.
+     */
+    psa_status_t status;
+    status = psa_crypto_init();
+    if( status != PSA_SUCCESS )
+    {
+        printf("psa_crypto_init() failed with %d\r\n", status );
+        return MBEDTLS_EXIT_FAILURE;
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     if((exit_code = mbedtls_platform_setup(NULL)) != 0) {
         printf("Platform initialization failed with error %d\r\n", exit_code);

--- a/tls-client/main.cpp
+++ b/tls-client/main.cpp
@@ -55,6 +55,11 @@ int main()
 {
     int exit_code = MBEDTLS_EXIT_FAILURE;
 
+    if((exit_code = mbedtls_platform_setup(NULL)) != 0) {
+        printf("Platform initialization failed with error %d\r\n", exit_code);
+        return MBEDTLS_EXIT_FAILURE;
+    }
+
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     /*
      * Initialize underlying PSA Crypto implementation.
@@ -73,10 +78,6 @@ int main()
     }
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
-    if((exit_code = mbedtls_platform_setup(NULL)) != 0) {
-        printf("Platform initialization failed with error %d\r\n", exit_code);
-        return MBEDTLS_EXIT_FAILURE;
-    }
     /*
      * The default 9600 bps is too slow to print full TLS debug info and could
      * cause the other party to time out.

--- a/tls-client/mbedtls_entropy_config.h
+++ b/tls-client/mbedtls_entropy_config.h
@@ -36,4 +36,14 @@
 #undef MBEDTLS_MPI_MAX_SIZE
 #define MBEDTLS_MPI_MAX_SIZE        256
 
+/* This macro determines whether Mbed TLS uses its own legacy crypto library
+ * or an implementation of the PSA Crypto API such as Mbed Crypto.
+ *
+ * To confirm the use of PSA Crypto, you may enable debugging by setting
+ * HELLO_HTTPS_CLIENT_DEBUG_LEVEL in HelloHttpsClient.h and look for
+ * PSA-related debugging output on the serial line.
+ *
+ * Uncomment this to use the PSA Crypto API. */
+//#define MBEDTLS_USE_PSA_CRYPTO
+
 #define MBEDTLS_MPI_WINDOW_SIZE     1


### PR DESCRIPTION
__Summary:__ This PR allows the use of PSA Crypto in the TLS client example by adding the necessary `psa_crypto_init()` call to the initialization code.

To use, define `MBEDTLS_USE_PSA_CRYPTO` in `mbedtls_entropy_config.h` before invoking `mbed compile`. No further changes are necessary.