### PR TITLE
Updating mbed-os to mbed-os-5.11.3

### DIFF
--- a/authcrypt/mbed-os.lib
+++ b/authcrypt/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a8f0c33eaa2c52babff9655417c36f4b5edd54d7
+https://github.com/ARMmbed/mbed-os/#a8d1d26fa76a27263cc9a69f65df45e3458517a5

--- a/benchmark/mbed-os.lib
+++ b/benchmark/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a8f0c33eaa2c52babff9655417c36f4b5edd54d7
+https://github.com/ARMmbed/mbed-os/#a8d1d26fa76a27263cc9a69f65df45e3458517a5

--- a/hashing/mbed-os.lib
+++ b/hashing/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a8f0c33eaa2c52babff9655417c36f4b5edd54d7
+https://github.com/ARMmbed/mbed-os/#a8d1d26fa76a27263cc9a69f65df45e3458517a5

--- a/tls-client/mbed-os.lib
+++ b/tls-client/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a8f0c33eaa2c52babff9655417c36f4b5edd54d7
+https://github.com/ARMmbed/mbed-os/#a8d1d26fa76a27263cc9a69f65df45e3458517a5


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.11.3 . 