### PR TITLE
Updating mbed-os to mbed-os-5.12.0-rc3

### DIFF
--- a/authcrypt/mbed-os.lib
+++ b/authcrypt/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c0939781ea1fa50657e055867193b62b1c9a6035
+https://github.com/ARMmbed/mbed-os/#85cbc290a2b4a5458cc1ae98c2a5bd6a4fd8758b

--- a/benchmark/mbed-os.lib
+++ b/benchmark/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c0939781ea1fa50657e055867193b62b1c9a6035
+https://github.com/ARMmbed/mbed-os/#85cbc290a2b4a5458cc1ae98c2a5bd6a4fd8758b

--- a/hashing/mbed-os.lib
+++ b/hashing/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c0939781ea1fa50657e055867193b62b1c9a6035
+https://github.com/ARMmbed/mbed-os/#85cbc290a2b4a5458cc1ae98c2a5bd6a4fd8758b

--- a/tls-client/mbed-os.lib
+++ b/tls-client/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c0939781ea1fa50657e055867193b62b1c9a6035
+https://github.com/ARMmbed/mbed-os/#85cbc290a2b4a5458cc1ae98c2a5bd6a4fd8758b


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.12.0-rc3 . 