### PR TITLE
Updating mbed-os to mbed-os-5.13.0

### DIFF
--- a/authcrypt/mbed-os.lib
+++ b/authcrypt/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#92a58dff9960788a3582b0f6dced1d5280b7f2f8
+https://github.com/ARMmbed/mbed-os/#7482462434d5cf718177653ef797547a976a7c5e

--- a/benchmark/mbed-os.lib
+++ b/benchmark/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#92a58dff9960788a3582b0f6dced1d5280b7f2f8
+https://github.com/ARMmbed/mbed-os/#7482462434d5cf718177653ef797547a976a7c5e

--- a/hashing/mbed-os.lib
+++ b/hashing/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#92a58dff9960788a3582b0f6dced1d5280b7f2f8
+https://github.com/ARMmbed/mbed-os/#7482462434d5cf718177653ef797547a976a7c5e

--- a/tls-client/mbed-os.lib
+++ b/tls-client/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#92a58dff9960788a3582b0f6dced1d5280b7f2f8
+https://github.com/ARMmbed/mbed-os/#7482462434d5cf718177653ef797547a976a7c5e


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag the corresponding 
release branch with mbed-os-5.13.0 . 