### PR TITLE
Fix CTR_DRBG benchmark

### DIFF
--- a/benchmark/main.cpp
+++ b/benchmark/main.cpp
@@ -805,22 +805,21 @@ MBED_NOINLINE static int benchmark_ctr_drbg()
     mbedtls_ctr_drbg_context ctr_drbg;
 
     mbedtls_ctr_drbg_init(&ctr_drbg);
-
     ret = mbedtls_ctr_drbg_seed(&ctr_drbg, myrand, NULL, NULL, 0);
     if (ret != 0) {
         PRINT_ERROR(ret, "mbedtls_ctr_drbg_seed()");
         goto exit;
     }
-
     BENCHMARK_FUNC_CALL(nopr_title,
                         mbedtls_ctr_drbg_random(&ctr_drbg, buf, BUFSIZE));
+    mbedtls_ctr_drbg_free(&ctr_drbg);
 
+    mbedtls_ctr_drbg_init(&ctr_drbg);
     ret = mbedtls_ctr_drbg_seed(&ctr_drbg, myrand, NULL, NULL, 0);
     if (ret != 0) {
         PRINT_ERROR(ret, "mbedtls_ctr_drbg_seed()");
         goto exit;
     }
-
     mbedtls_ctr_drbg_set_prediction_resistance(&ctr_drbg,
             MBEDTLS_CTR_DRBG_PR_ON);
     BENCHMARK_FUNC_CALL(pr_title,


### PR DESCRIPTION
You can't reuse a CTR_DRBG context without free()ing it and
re-init()ing it. This generally happened to work, but was never
guaranteed. It could have failed with alternative implementations of
the AES module because mbedtls_ctr_drbg_seed() calls
mbedtls_aes_init() on a context which is already initialized if
mbedtls_ctr_drbg_seed() hasn't been called before, plausibly causing a
memory leak. Calling free() and seed() with no intervening init fails
when MBEDTLS_THREADING_C is enabled and all-bits-zero is not a valid
mutex representation. So add the missing free() and init().

The same code exists in mbed-crypto and is fixed in https://github.com/ARMmbed/mbed-crypto/pull/305.