### PR TITLE
Updating mbed-os to mbed-os-5.15.0-rc2

### DIFF
--- a/authcrypt/mbed-os.lib
+++ b/authcrypt/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b14f495aa23fc62355abd9f892f55c34731ce606
+https://github.com/ARMmbed/mbed-os/#5d7f5bd82b5cc9114818ec2f708b6a1c4ec6206d

--- a/benchmark/mbed-os.lib
+++ b/benchmark/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b14f495aa23fc62355abd9f892f55c34731ce606
+https://github.com/ARMmbed/mbed-os/#5d7f5bd82b5cc9114818ec2f708b6a1c4ec6206d

--- a/hashing/mbed-os.lib
+++ b/hashing/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b14f495aa23fc62355abd9f892f55c34731ce606
+https://github.com/ARMmbed/mbed-os/#5d7f5bd82b5cc9114818ec2f708b6a1c4ec6206d

--- a/tls-client/mbed-os.lib
+++ b/tls-client/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b14f495aa23fc62355abd9f892f55c34731ce606
+https://github.com/ARMmbed/mbed-os/#5d7f5bd82b5cc9114818ec2f708b6a1c4ec6206d


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag the corresponding 
release branch with mbed-os-5.15.0-rc2 . 