### PR TITLE
Make compatible with Minimal-printf

### DIFF
--- a/hashing/main.cpp
+++ b/hashing/main.cpp
@@ -37,8 +37,13 @@ static void print_hex(const char *title, const unsigned char buf[], size_t len)
 {
     mbedtls_printf("%s: ", title);
 
-    for (size_t i = 0; i < len; i++)
-        mbedtls_printf("%02x", buf[i]);
+    for (size_t i = 0; i < len; i++) {
+        if (buf[i] < 0xF) {
+            mbedtls_printf("0%x", buf[i]);
+        } else {
+            mbedtls_printf("%x", buf[i]);
+        }
+    }
 
     mbedtls_printf("\n");
 }


### PR DESCRIPTION
Remove flags and width format sub-specifiers on `printf()` calls as
[Minimal-printf ](https://github.com/ARMmbed/mbed-os/tree/master/platform/source/minimal-printf#usage)does not support them. This commit ensures that the
output when built with Minimal-printf is legible and similar to the
output when using the standard library.

Reviewers
@Patater @evedon 