### PR TITLE
Remove deprecated Socket String-based API usage

### DIFF
--- a/tls-client/HelloHttpsClient.cpp
+++ b/tls-client/HelloHttpsClient.cpp
@@ -110,7 +110,11 @@ int HelloHttpsClient::run()
         return ret;
 
     /* Start a connection to the server */
-    if ((ret = socket.connect(server_addr, server_port)) != NSAPI_ERROR_OK) {
+    SocketAddress saddr;
+    NetworkInterface *network = NetworkInterface::get_default_instance();
+    network->gethostbyname(server_addr, &saddr);
+    saddr.set_port(server_port);
+    if ((ret = socket.connect(saddr)) != NSAPI_ERROR_OK) {
         mbedtls_printf("socket.connect() returned %d\n", ret);
         return ret;
     }


### PR DESCRIPTION
See https://github.com/ARMmbed/mbed-os/pull/11914 for deprecation details.

SocketAddress-base API should be used instead.