### PR TITLE
Updating mbed-os to mbed-os-5.15.2

### DIFF
--- a/authcrypt/mbed-os.lib
+++ b/authcrypt/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#64853b354fa188bfe8dbd51e78771213c7ed37f7
+https://github.com/ARMmbed/mbed-os/#565ab149819481224ab43f878c3921b14b11d180

--- a/benchmark/mbed-os.lib
+++ b/benchmark/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#64853b354fa188bfe8dbd51e78771213c7ed37f7
+https://github.com/ARMmbed/mbed-os/#565ab149819481224ab43f878c3921b14b11d180

--- a/hashing/mbed-os.lib
+++ b/hashing/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#64853b354fa188bfe8dbd51e78771213c7ed37f7
+https://github.com/ARMmbed/mbed-os/#565ab149819481224ab43f878c3921b14b11d180

--- a/tls-client/mbed-os.lib
+++ b/tls-client/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#64853b354fa188bfe8dbd51e78771213c7ed37f7
+https://github.com/ARMmbed/mbed-os/#565ab149819481224ab43f878c3921b14b11d180


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag the corresponding 
release branch with mbed-os-5.15.2 . 