### PR TITLE
Updating mbed-os to mbed-os-5.15.4

### DIFF
--- a/authcrypt/mbed-os.lib
+++ b/authcrypt/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b6370b4c37f3d4665ed1cdcb1afea85396bba1b3
+https://github.com/ARMmbed/mbed-os/#0515ed1f9fa318b023a7dc21bdb3fb16de37b025

--- a/benchmark/mbed-os.lib
+++ b/benchmark/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b6370b4c37f3d4665ed1cdcb1afea85396bba1b3
+https://github.com/ARMmbed/mbed-os/#0515ed1f9fa318b023a7dc21bdb3fb16de37b025

--- a/hashing/mbed-os.lib
+++ b/hashing/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b6370b4c37f3d4665ed1cdcb1afea85396bba1b3
+https://github.com/ARMmbed/mbed-os/#0515ed1f9fa318b023a7dc21bdb3fb16de37b025

--- a/tls-client/mbed-os.lib
+++ b/tls-client/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b6370b4c37f3d4665ed1cdcb1afea85396bba1b3
+https://github.com/ARMmbed/mbed-os/#0515ed1f9fa318b023a7dc21bdb3fb16de37b025


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag the corresponding 
release branch with mbed-os-5.15.4 . 