### PR TITLE
Update for mbed-os-6.7.0

### DIFF
--- a/authcrypt/mbed-os.lib
+++ b/authcrypt/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/
+https://github.com/ARMmbed/mbed-os/#0c6753bb821612eb72b5f682aed7ffcc98e80a1f

--- a/benchmark/mbed-os.lib
+++ b/benchmark/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/
+https://github.com/ARMmbed/mbed-os/#0c6753bb821612eb72b5f682aed7ffcc98e80a1f

--- a/hashing/mbed-os.lib
+++ b/hashing/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/
+https://github.com/ARMmbed/mbed-os/#0c6753bb821612eb72b5f682aed7ffcc98e80a1f

--- a/tls-client/mbed-os.lib
+++ b/tls-client/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/
+https://github.com/ARMmbed/mbed-os/#0c6753bb821612eb72b5f682aed7ffcc98e80a1f


### PR DESCRIPTION
This pull request updates the example to be compatible with the 
mbed-os-6.7.0 release of mbed-os. 