### PR TITLE
CMake: Make applications the top level CMake projects

### DIFF
--- a/authcrypt/CMakeLists.txt
+++ b/authcrypt/CMakeLists.txt
@@ -9,11 +9,11 @@ set(APP_TARGET authcrypt)
 
 include(${MBED_PATH}/tools/cmake/app.cmake)
 
+project(${APP_TARGET})
+
 add_subdirectory(${MBED_PATH})
 
 add_executable(${APP_TARGET})
-
-project(${APP_TARGET})
 
 target_include_directories(${APP_TARGET}
     PRIVATE

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -9,11 +9,11 @@ set(APP_TARGET benchmark)
 
 include(${MBED_PATH}/tools/cmake/app.cmake)
 
+project(${APP_TARGET})
+
 add_subdirectory(${MBED_PATH})
 
 add_executable(${APP_TARGET})
-
-project(${APP_TARGET})
 
 target_include_directories(${APP_TARGET}
     PRIVATE

--- a/hashing/CMakeLists.txt
+++ b/hashing/CMakeLists.txt
@@ -9,12 +9,11 @@ set(APP_TARGET hashing)
 
 include(${MBED_PATH}/tools/cmake/app.cmake)
 
+project(${APP_TARGET})
+
 add_subdirectory(${MBED_PATH})
 
 add_executable(${APP_TARGET})
-
-project(${APP_TARGET})
-
 
 target_sources(${APP_TARGET}
     PRIVATE

--- a/tls-client/CMakeLists.txt
+++ b/tls-client/CMakeLists.txt
@@ -9,11 +9,11 @@ set(APP_TARGET tls-client)
 
 include(${MBED_PATH}/tools/cmake/app.cmake)
 
+project(${APP_TARGET})
+
 add_subdirectory(${MBED_PATH})
 
 add_executable(${APP_TARGET})
-
-project(${APP_TARGET})
 
 target_include_directories(${APP_TARGET}
     PRIVATE


### PR DESCRIPTION
So CMake can work correctly we need to define our project before we add
dependencies, otherwise the project we depend on will be registered as
the current project.