### PR TITLE
benchmark: Remove Mbed TLS 3.0 removed crypto

### DIFF
--- a/benchmark/mbedtls_config.h
+++ b/benchmark/mbedtls_config.h
@@ -17,10 +17,6 @@
  *  This file is part of Mbed TLS (https://tls.mbed.org)
  */
 
-#if !defined(MBEDTLS_MD4_C)
-#define MBEDTLS_MD4_C
-#endif
-
 #if !defined(MBEDTLS_MD5_C)
 #define MBEDTLS_MD5_C
 #endif
@@ -39,10 +35,6 @@
 
 #if !defined(MBEDTLS_SHA512_C)
 #define MBEDTLS_SHA512_C
-#endif
-
-#if !defined(MBEDTLS_ARC4_C)
-#define MBEDTLS_ARC4_C
 #endif
 
 #if !defined(MBEDTLS_DES_C)
@@ -71,10 +63,6 @@
 
 #if !defined(MBEDTLS_CAMELLIA_C)
 #define MBEDTLS_CAMELLIA_C
-#endif
-
-#if !defined(MBEDTLS_BLOWFISH_C)
-#define MBEDTLS_BLOWFISH_C
 #endif
 
 #if !defined(MBEDTLS_CTR_DRBG_C)


### PR DESCRIPTION
To help the benchmark application be more portable between Mbed TLS 2.x
and 3.x, avoid enabling any crypto that Mbed TLS 3.x has removed.